### PR TITLE
feat/date-filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ For most endpoints, a Bearer token will need to be provided. Below are steps for
 * Step 2: Point to the `clients.json` file in your `ConfigDebug.json` file. Example `ConfigDebug.json`:
 ```json
 {
-    "db": "mongodb://localhost:27017/",
+    "db": "mongodb://0.0.0.0:27017/",
     "guildId": "156175293055369216",
     "clientsFile": "./clients.json"
 }

--- a/postman/RTI API.postman_collection.json
+++ b/postman/RTI API.postman_collection.json
@@ -1,3154 +1,3698 @@
 {
-  "info": {
-    "_postman_id": "f75e1372-a24a-4d69-9591-88b3a0efe74c",
-    "name": "RTI API",
-    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
-  },
-  "item": [
-    {
-      "name": "Raids",
-      "item": [
-        {
-          "name": "List",
-          "item": [
-            {
-              "name": "All Raids",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [""],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{baseUrl}}/raids",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["raids"]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "Raids Page 1",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"Number of raids test\", function () {\r",
-                      "    const responseJson = pm.response.json();\r",
-                      "    pm.expect(responseJson.length).to.eql(20);\r",
-                      "});"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{baseUrl}}/raids?page=1&pageSize=20",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["raids"],
-                  "query": [
-                    {
-                      "key": "page",
-                      "value": "1"
-                    },
-                    {
-                      "key": "pageSize",
-                      "value": "20"
-                    }
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "Name Search",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "const jsonData = pm.response.json()\r",
-                      "\r",
-                      "pm.test(\"All raid names contain the specified string\", () => {\r",
-                      "    _.each(jsonData, (item) => {\r",
-                      "        pm.expect(item.name.toLowerCase()).to.contain(pm.request.url.getQueryString().split(\"=\")[1]);\r",
-                      "    })\r",
-                      "})"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{baseUrl}}/raids?name=continuation",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["raids"],
-                  "query": [
-                    {
-                      "key": "name",
-                      "value": "continuation"
-                    }
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "Search Participants",
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{baseUrl}}/raids?participants=step%230,akronox%230",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["raids"],
-                  "query": [
-                    {
-                      "key": "participants",
-                      "value": "Step#1937,Christin#0112"
-                    }
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "Search Reserves",
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{baseUrl}}/raids?reserves=step%230",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["raids"],
-                  "query": [
-                    {
-                      "key": "reserves",
-                      "value": "step%230"
-                    }
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "Only Draft & Published Raids",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "const jsonData = pm.response.json()\r",
-                      "\r",
-                      "pm.test(\"All raids are either draft or published\", () => {\r",
-                      "    _.each(jsonData, (item) => {\r",
-                      "        pm.expect(item.status.toLowerCase()).to.be.oneOf(pm.request.url.getQueryString().toLowerCase().split(\"=\")[1].split(\",\"));\r",
-                      "    })\r",
-                      "})"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{baseUrl}}/raids?status=draft,published",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["raids"],
-                  "query": [
-                    {
-                      "key": "status",
-                      "value": "draft,published"
-                    }
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "Archived Raids With Comps",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "const jsonData = pm.response.json()\r",
-                      "\r",
-                      "pm.test(\"All raids have the specified leader\", () => {\r",
-                      "    _.each(jsonData, (item) => {\r",
-                      "        pm.expect(item.status.toLowerCase()).to.be.oneOf(pm.request.url.getQueryString().split(\"&\")[0].split(\"=\")[1].split(\",\"));\r",
-                      "    })\r",
-                      "})"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{baseUrl}}/raids?status=archived&comps=Dhuum-RR,SoullessHorror",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["raids"],
-                  "query": [
-                    {
-                      "key": "status",
-                      "value": "archived"
-                    },
-                    {
-                      "key": "comps",
-                      "value": "Dhuum-RR,SoullessHorror"
-                    }
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "Filter by Leader",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "const jsonData = pm.response.json()\r",
-                      "\r",
-                      "pm.test(\"All raids have the specified leader\", () => {\r",
-                      "    _.each(jsonData, (item) => {\r",
-                      "        pm.expect(item.leader).to.eql(pm.request.url.getQueryString().split(\"=\")[1].replace(\"%23\", \"#\"))\r",
-                      "    })\r",
-                      "})"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{baseUrl}}/raids?leader=step%230",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["raids"],
-                  "query": [
-                    {
-                      "key": "leader",
-                      "value": "step%230"
-                    }
-                  ]
-                }
-              },
-              "response": []
-            }
-          ],
-          "event": [
-            {
-              "listen": "prerequest",
-              "script": {
-                "type": "text/javascript",
-                "exec": [""]
-              }
-            },
-            {
-              "listen": "test",
-              "script": {
-                "type": "text/javascript",
-                "exec": [
-                  "const schema = {",
-                  "    \"type\": \"array\",",
-                  "    \"items\": {",
-                  "        \"type\": \"object\",",
-                  "        \"required\": [\"name\", \"status\", \"startTime\", \"endTime\", \"id\"],",
-                  "        \"properties\": {",
-                  "            \"name\": { \"type\": \"string\" },",
-                  "            \"status\": { \"type\": \"string\", \"enum\": [\"Archived\", \"Draft\", \"Published\"] },",
-                  "            \"startTime\": { \"type\": \"string\", \"pattern\": \"^(19|20)\\\\d\\\\d-(0[1-9]|1[012])-([012]\\\\d|3[01])T([01]\\\\d|2[0-3]):([0-5]\\\\d):([0-5]\\\\d)$\" },",
-                  "            \"endTime\": { \"type\": \"string\", \"pattern\": \"^(19|20)\\\\d\\\\d-(0[1-9]|1[012])-([012]\\\\d|3[01])T([01]\\\\d|2[0-3]):([0-5]\\\\d):([0-5]\\\\d)$\" },",
-                  "            \"publishedDate\": { \"type\": \"string\", \"pattern\": \"^(19|20)\\\\d\\\\d-(0[1-9]|1[012])-([012]\\\\d|3[01])T([01]\\\\d|2[0-3]):([0-5]\\\\d):([0-5]\\\\d)$\" },",
-                  "            \"leader\": { \"type\": \"string\" },",
-                  "            \"comp\": { \"type\": \"string\" },",
-                  "            \"id\": { \"type\": \"string\" }",
-                  "        },",
-                  "        \"additionalProperties\": false",
-                  "    }",
-                  "}",
-                  "",
-                  "pm.test(\"Status test\", function () {",
-                  "    pm.response.to.have.status(200);",
-                  "});",
-                  "",
-                  "pm.test(\"Content-Type is present\", function () {",
-                  "    pm.response.to.have.header(\"Content-Type\");",
-                  "});",
-                  "",
-                  "pm.test(\"Schema test\", function () {",
-                  "    pm.response.to.have.jsonSchema(schema);",
-                  "});"
-                ]
-              }
-            }
-          ]
-        },
-        {
-          "name": "Get",
-          "item": [
-            {
-              "name": "Existent Raid",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [""],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{baseUrl}}/raids/602711570e73df0012df74f9",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["raids", "602711570e73df0012df74f9"]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "Raid with GW2 Names",
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{baseUrl}}/raids/602711570e73df0012df74f9?names=gw2",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["raids", "602711570e73df0012df74f9"],
-                  "query": [
-                    {
-                      "key": "names",
-                      "value": "gw2"
-                    }
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "Raid with Discord Names",
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{baseUrl}}/raids/6027115a0e73df0012dfa185?names=discord",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["raids", "6027115a0e73df0012dfa185"],
-                  "query": [
-                    {
-                      "key": "names",
-                      "value": "discord"
-                    }
-                  ]
-                }
-              },
-              "response": []
-            }
-          ],
-          "event": [
-            {
-              "listen": "prerequest",
-              "script": {
-                "type": "text/javascript",
-                "exec": [""]
-              }
-            },
-            {
-              "listen": "test",
-              "script": {
-                "type": "text/javascript",
-                "exec": [
-                  "const schema = {",
-                  "    \"type\": \"object\",",
-                  "    \"required\": [\"name\", \"status\", \"startTime\", \"endTime\", \"leader\", \"id\", \"participants\", \"reserves\"],",
-                  "    \"properties\": {",
-                  "        \"name\": { \"type\": \"string\" },",
-                  "        \"description\": { \"type\": \"string\" },",
-                  "        \"status\": { \"type\": \"string\", \"enum\": [\"Archived\", \"Draft\", \"Published\"] },",
-                  "        \"startTime\": { \"type\": \"string\", \"pattern\": \"^(19|20)\\\\d\\\\d-(0[1-9]|1[012])-([012]\\\\d|3[01])T([01]\\\\d|2[0-3]):([0-5]\\\\d):([0-5]\\\\d)$\" },",
-                  "        \"endTime\": { \"type\": \"string\", \"pattern\": \"^(19|20)\\\\d\\\\d-(0[1-9]|1[012])-([012]\\\\d|3[01])T([01]\\\\d|2[0-3]):([0-5]\\\\d):([0-5]\\\\d)$\" },",
-                  "        \"publishedDate\": { \"type\": \"string\", \"pattern\": \"^(19|20)\\\\d\\\\d-(0[1-9]|1[012])-([012]\\\\d|3[01])T([01]\\\\d|2[0-3]):([0-5]\\\\d):([0-5]\\\\d)$\" },",
-                  "        \"leader\": { \"type\": \"string\" },",
-                  "        \"comp\": { \"type\": \"string\" },",
-                  "        \"channelId\": { \"type\": \"string\" },",
-                  "        \"participants\": {",
-                  "            \"type\": \"array\",",
-                  "            \"items\": {",
-                  "                \"properties\": {",
-                  "                    \"role\": { \"type\": \"string\" },",
-                  "                    \"requiredParticipants\": { \"type\": \"number\" },",
-                  "                    \"members\": { \"type\": \"array\", \"items\": { \"type\": [\"string\", \"null\"]}}",
-                  "                },",
-                  "                \"additionalProperties\": false",
-                  "            }",
-                  "        },",
-                  "        \"reserves\": {",
-                  "            \"type\": \"array\",",
-                  "            \"items\": {",
-                  "                \"properties\": {",
-                  "                    \"role\": { \"type\": \"string\" },",
-                  "                    \"requiredParticipants\": { \"type\": \"number\" },",
-                  "                    \"members\": { \"type\": \"array\", \"items\": { \"type\": [\"string\", \"null\"]}}",
-                  "                },",
-                  "                \"additionalProperties\": false",
-                  "            }",
-                  "        },",
-                  "        \"id\": { \"type\": \"string\" }",
-                  "    },",
-                  "    \"additionalProperties\": false",
-                  "}",
-                  "",
-                  "pm.test(\"Status test\", function () {",
-                  "    pm.response.to.have.status(200);",
-                  "});",
-                  "",
-                  "pm.test(\"Content-Type is present\", function () {",
-                  "    pm.response.to.have.header(\"Content-Type\");",
-                  "});",
-                  "",
-                  "pm.test(\"Schema test\", function () {",
-                  "    pm.response.to.have.jsonSchema(schema);",
-                  "});"
-                ]
-              }
-            }
-          ]
-        },
-        {
-          "name": "List CSV",
-          "item": [
-            {
-              "name": "All Raids as CSV",
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{baseUrl}}/raids?format=csv",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["raids"],
-                  "query": [
-                    {
-                      "key": "format",
-                      "value": "csv"
-                    }
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "Published Raids as CSV",
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{baseUrl}}/raids?format=csv&published=true",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["raids"],
-                  "query": [
-                    {
-                      "key": "format",
-                      "value": "csv"
-                    },
-                    {
-                      "key": "published",
-                      "value": "true"
-                    }
-                  ]
-                }
-              },
-              "response": []
-            }
-          ],
-          "event": [
-            {
-              "listen": "prerequest",
-              "script": {
-                "type": "text/javascript",
-                "exec": [""]
-              }
-            },
-            {
-              "listen": "test",
-              "script": {
-                "type": "text/javascript",
-                "exec": [
-                  "pm.test(\"Status test\", function () {",
-                  "    pm.response.to.have.status(200);",
-                  "});",
-                  "",
-                  "pm.test(\"Content-Type is present\", function () {",
-                  "    pm.response.to.have.header(\"Content-Type\");",
-                  "});"
-                ]
-              }
-            }
-          ]
-        },
-        {
-          "name": "Errors",
-          "item": [
-            {
-              "name": "Wrong Status",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"Status test\", function () {\r",
-                      "    pm.response.to.have.status(400);\r",
-                      "});"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{baseUrl}}/raids?status=druft",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["raids"],
-                  "query": [
-                    {
-                      "key": "status",
-                      "value": "druft"
-                    }
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "Wrong Published",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"Status test\", function () {\r",
-                      "    pm.response.to.have.status(400);\r",
-                      "});"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{baseUrl}}/raids?pageSize=20",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["raids"],
-                  "query": [
-                    {
-                      "key": "pageSize",
-                      "value": "20"
-                    }
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "Bad Authentication",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"Status test\", function () {\r",
-                      "    pm.response.to.have.status(401);\r",
-                      "});"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "GET",
-                "header": [
-                  {
-                    "key": "Authorization",
-                    "value": "Bearer 1234567890",
-                    "type": "text"
-                  }
-                ],
-                "url": {
-                  "raw": "{{baseUrl}}/raids",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["raids"]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "Page Without PageSize",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"Status test\", function () {\r",
-                      "    pm.response.to.have.status(400);\r",
-                      "});"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{baseUrl}}/raids?page=1",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["raids"],
-                  "query": [
-                    {
-                      "key": "page",
-                      "value": "1"
-                    }
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "PageSize Without Page",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"Status test\", function () {\r",
-                      "    pm.response.to.have.status(400);\r",
-                      "});"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{baseUrl}}/raids?pageSize=20",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["raids"],
-                  "query": [
-                    {
-                      "key": "pageSize",
-                      "value": "20"
-                    }
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "Wrong Format",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"Status test\", function () {\r",
-                      "    pm.response.to.have.status(400);\r",
-                      "});"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{baseUrl}}/raids?format=txt",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["raids"],
-                  "query": [
-                    {
-                      "key": "format",
-                      "value": "txt"
-                    }
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "Nonexistent Raid",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"Status test\", function () {\r",
-                      "    pm.response.to.have.status(404);\r",
-                      "});"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{baseUrl}}/raids/111111111111111111111111",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["raids", "111111111111111111111111"]
-                }
-              },
-              "response": []
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "name": "Members",
-      "item": [
-        {
-          "name": "List",
-          "item": [
-            {
-              "name": "All Members",
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{baseUrl}}/members",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["members"]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "Members Page 1",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"Number of members test\", function () {\r",
-                      "    const responseJson = pm.response.json();\r",
-                      "    pm.expect(responseJson.length).to.eql(20);\r",
-                      "});"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{baseUrl}}/members?page=1&pageSize=20",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["members"],
-                  "query": [
-                    {
-                      "key": "page",
-                      "value": "1"
-                    },
-                    {
-                      "key": "pageSize",
-                      "value": "20"
-                    }
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "gw2Name Search",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "const jsonData = pm.response.json()\r",
-                      "\r",
-                      "pm.test(\"All members contain the specified string\", () => {\r",
-                      "    _.each(jsonData, (item) => {\r",
-                      "        pm.expect(item.gw2Name.toLowerCase()).to.contain(pm.request.url.getQueryString().split(\"=\")[1].toLowerCase());\r",
-                      "    })\r",
-                      "})"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{baseUrl}}/members?gw2Name=Step",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["members"],
-                  "query": [
-                    {
-                      "key": "gw2Name",
-                      "value": "Step"
-                    }
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "discordTag Search",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "const jsonData = pm.response.json()\r",
-                      "\r",
-                      "pm.test(\"All members contain the specified string\", () => {\r",
-                      "    _.each(jsonData, (item) => {\r",
-                      "        pm.expect(item.discordTag.toLowerCase()).to.contain(pm.request.url.getQueryString().split(\"=\")[1].toLowerCase());\r",
-                      "    })\r",
-                      "})"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{baseUrl}}/members?discordTag=Step",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["members"],
-                  "query": [
-                    {
-                      "key": "discordTag",
-                      "value": "Step"
-                    }
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "Filter by Approver",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "const jsonData = pm.response.json()\r",
-                      "\r",
-                      "pm.test(\"All members have the specified approver\", () => {\r",
-                      "    _.each(jsonData, (item) => {\r",
-                      "        pm.expect(item.approver).to.eql(pm.request.url.getQueryString().split(\"=\")[1].replace(\"%23\", \"#\"))\r",
-                      "    })\r",
-                      "})"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{baseUrl}}/members?approver=step%230",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["members"],
-                  "query": [
-                    {
-                      "key": "approver",
-                      "value": "step%230"
-                    }
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "Only Unbanned Members",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "const jsonData = pm.response.json()\r",
-                      "\r",
-                      "pm.test(\"All members are unbanned\", () => {\r",
-                      "    _.each(jsonData, (item) => {\r",
-                      "        pm.expect(item.banned).to.eql(pm.request.url.getQueryString().split(\"=\")[1] == \"true\")\r",
-                      "    })\r",
-                      "})"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{baseUrl}}/members?banned=false",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["members"],
-                  "query": [
-                    {
-                      "key": "banned",
-                      "value": "false"
-                    }
-                  ]
-                }
-              },
-              "response": []
-            }
-          ],
-          "event": [
-            {
-              "listen": "prerequest",
-              "script": {
-                "type": "text/javascript",
-                "exec": [""]
-              }
-            },
-            {
-              "listen": "test",
-              "script": {
-                "type": "text/javascript",
-                "exec": [
-                  "const schema = {",
-                  "    \"type\": \"array\",",
-                  "    \"items\": {",
-                  "        \"type\": \"object\",",
-                  "        \"required\": [\"gw2Name\", \"approver\", \"userId\", \"banned\"],",
-                  "        \"properties\": {",
-                  "            \"gw2Name\": { \"type\": \"string\" },",
-                  "            \"discordName\": { \"type\": \"string\" },",
-                  "            \"discordTag\": { \"type\": \"string\" },",
-                  "            \"approver\": { \"type\": \"string\" },",
-                  "            \"userId\": { \"type\": \"string\" },",
-                  "            \"banned\": { \"type\": \"boolean\" }",
-                  "        },",
-                  "        \"additionalProperties\": false",
-                  "    }",
-                  "}",
-                  "",
-                  "pm.test(\"Status test\", function () {",
-                  "    pm.response.to.have.status(200);",
-                  "});",
-                  "",
-                  "pm.test(\"Content-Type is present\", function () {",
-                  "    pm.response.to.have.header(\"Content-Type\");",
-                  "});",
-                  "",
-                  "pm.test(\"Schema test\", function () {",
-                  "    pm.response.to.have.jsonSchema(schema);",
-                  "});"
-                ]
-              }
-            }
-          ]
-        },
-        {
-          "name": "Get",
-          "item": [
-            {
-              "name": "Existent Member",
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{baseUrl}}/members/82136625345200128",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["members", "82136625345200128"]
-                }
-              },
-              "response": []
-            }
-          ],
-          "event": [
-            {
-              "listen": "prerequest",
-              "script": {
-                "type": "text/javascript",
-                "exec": [""]
-              }
-            },
-            {
-              "listen": "test",
-              "script": {
-                "type": "text/javascript",
-                "exec": [
-                  "const schema = {",
-                  "    \"type\": \"object\",",
-                  "    \"required\": [\"gw2Name\", \"discordName\", \"discordTag\", \"approver\", \"userId\", \"banned\"],",
-                  "    \"properties\": {",
-                  "        \"gw2Name\": { \"type\": \"string\" },",
-                  "        \"discordName\": { \"type\": \"string\" },",
-                  "        \"discordTag\": { \"type\": \"string\" },",
-                  "        \"approver\": { \"type\": \"string\" },",
-                  "        \"userId\": { \"type\": \"string\" },",
-                  "        \"banned\": { \"type\": \"boolean\" }",
-                  "    },",
-                  "    \"additionalProperties\": false",
-                  "}",
-                  "",
-                  "pm.test(\"Status test\", function () {",
-                  "    pm.response.to.have.status(200);",
-                  "});",
-                  "",
-                  "pm.test(\"Content-Type is present\", function () {",
-                  "    pm.response.to.have.header(\"Content-Type\");",
-                  "});",
-                  "",
-                  "pm.test(\"Schema test\", function () {",
-                  "    pm.response.to.have.jsonSchema(schema);",
-                  "});"
-                ]
-              }
-            }
-          ]
-        },
-        {
-          "name": "List CSV",
-          "item": [
-            {
-              "name": "All Members as CSV",
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{baseUrl}}/members?format=csv",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["members"],
-                  "query": [
-                    {
-                      "key": "format",
-                      "value": "csv"
-                    }
-                  ]
-                }
-              },
-              "response": []
-            }
-          ],
-          "event": [
-            {
-              "listen": "prerequest",
-              "script": {
-                "type": "text/javascript",
-                "exec": [""]
-              }
-            },
-            {
-              "listen": "test",
-              "script": {
-                "type": "text/javascript",
-                "exec": [
-                  "pm.test(\"Status test\", function () {",
-                  "    pm.response.to.have.status(200);",
-                  "});",
-                  "",
-                  "pm.test(\"Content-Type is present\", function () {",
-                  "    pm.response.to.have.header(\"Content-Type\");",
-                  "});"
-                ]
-              }
-            }
-          ]
-        },
-        {
-          "name": "Errors",
-          "item": [
-            {
-              "name": "Approver Not Found",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"Status test\", function () {\r",
-                      "    pm.response.to.have.status(404);\r",
-                      "});"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{baseUrl}}/members?approver=AbrahamLincoln",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["members"],
-                  "query": [
-                    {
-                      "key": "approver",
-                      "value": "AbrahamLincoln"
-                    }
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "Wrong Banned",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"Status test\", function () {\r",
-                      "    pm.response.to.have.status(400);\r",
-                      "});"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{baseUrl}}/members?banned=yes",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["members"],
-                  "query": [
-                    {
-                      "key": "banned",
-                      "value": "yes"
-                    }
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "Bad Authentication",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"Status test\", function () {\r",
-                      "    pm.response.to.have.status(401);\r",
-                      "});"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "GET",
-                "header": [
-                  {
-                    "key": "Authorization",
-                    "value": "Bearer 123456789",
-                    "type": "text"
-                  }
-                ],
-                "url": {
-                  "raw": "{{baseUrl}}/members",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["members"]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "Page Without PageSize",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"Status test\", function () {\r",
-                      "    pm.response.to.have.status(400);\r",
-                      "});"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{baseUrl}}/members?pageSize=20",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["members"],
-                  "query": [
-                    {
-                      "key": "pageSize",
-                      "value": "20"
-                    }
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "PageSize Without Page",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"Status test\", function () {\r",
-                      "    pm.response.to.have.status(400);\r",
-                      "});"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{baseUrl}}/members?page=1",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["members"],
-                  "query": [
-                    {
-                      "key": "page",
-                      "value": "1"
-                    }
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "Wrong Format",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"Status test\", function () {\r",
-                      "    pm.response.to.have.status(400);\r",
-                      "});"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{baseUrl}}/members?format=txt",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["members"],
-                  "query": [
-                    {
-                      "key": "format",
-                      "value": "txt"
-                    }
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "Nonexistent Member",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"Status test\", function () {\r",
-                      "    pm.response.to.have.status(404);\r",
-                      "});"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{baseUrl}}/members/11111111111111111",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["members", "11111111111111111"]
-                }
-              },
-              "response": []
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "name": "Comps",
-      "item": [
-        {
-          "name": "List",
-          "item": [
-            {
-              "name": "All Comps",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [""],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{baseUrl}}/comps",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["comps"]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "By Categories",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "const jsonData = pm.response.json()\r",
-                      "\r",
-                      "pm.test(\"All comps have one of the specified categories\", () => {\r",
-                      "    const queryCategoriesList = pm.request.url.getQueryString().split(\"=\")[1].replace(\"%20\", \" \").toLowerCase().split(\",\");\r",
-                      "    _.each(jsonData, (item) => {\r",
-                      "        const itemCategoriesList = item.categories.map(category => category.toLowerCase());\r",
-                      "        const filteredList = queryCategoriesList.filter(category => itemCategoriesList.includes(category));\r",
-                      "        pm.expect(filteredList.length).to.be.greaterThan(0);\r",
-                      "    })\r",
-                      "})"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{baseUrl}}/comps?categories=Generic,Wing%201",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["comps"],
-                  "query": [
-                    {
-                      "key": "categories",
-                      "value": "Generic,Wing%201"
-                    }
-                  ]
-                }
-              },
-              "response": []
-            }
-          ],
-          "event": [
-            {
-              "listen": "prerequest",
-              "script": {
-                "type": "text/javascript",
-                "exec": [""]
-              }
-            },
-            {
-              "listen": "test",
-              "script": {
-                "type": "text/javascript",
-                "exec": [
-                  "const schema = {",
-                  "    \"type\": \"array\",",
-                  "    \"items\": {",
-                  "        \"type\": \"object\",",
-                  "        \"required\": [\"name\", \"categories\", \"roles\"],",
-                  "        \"properties\": {",
-                  "            \"name\": { \"type\": \"string\" },",
-                  "            \"categories\": { \"type\": \"array\", \"items\": { \"type\": \"string\" } },",
-                  "            \"roles\": {",
-                  "                \"type\": \"array\",",
-                  "                \"items\": {",
-                  "                    \"type\": \"object\",",
-                  "                    \"required\": [\"name\", \"requiredParticipants\"],",
-                  "                    \"properties\": {",
-                  "                        \"name\": { \"type\": \"string\" },",
-                  "                        \"requiredParticipants\": { \"type\": \"number\" }",
-                  "                    },",
-                  "                    \"additionalProperties\": false",
-                  "                }",
-                  "            },",
-                  "        },",
-                  "        \"additionalProperties\": false",
-                  "    }",
-                  "}",
-                  "",
-                  "pm.test(\"Status test\", function () {",
-                  "    pm.response.to.have.status(200);",
-                  "});",
-                  "",
-                  "pm.test(\"Content-Type is present\", function () {",
-                  "    pm.response.to.have.header(\"Content-Type\");",
-                  "});",
-                  "",
-                  "pm.test(\"Schema test\", function () {",
-                  "    pm.response.to.have.jsonSchema(schema);",
-                  "});"
-                ]
-              }
-            }
-          ]
-        },
-        {
-          "name": "Get",
-          "item": [
-            {
-              "name": "Existent Comp",
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{baseUrl}}/comps/DoubleChrono",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["comps", "DoubleChrono"]
-                }
-              },
-              "response": []
-            }
-          ],
-          "event": [
-            {
-              "listen": "prerequest",
-              "script": {
-                "type": "text/javascript",
-                "exec": [""]
-              }
-            },
-            {
-              "listen": "test",
-              "script": {
-                "type": "text/javascript",
-                "exec": [
-                  "const schema = {",
-                  "    \"type\": \"object\",",
-                  "    \"required\": [\"name\", \"categories\", \"roles\"],",
-                  "    \"properties\": {",
-                  "        \"name\": { \"type\": \"string\" },",
-                  "        \"categories\": { \"type\": \"array\", \"items\": { \"type\": \"string\" } },",
-                  "        \"roles\": {",
-                  "            \"type\": \"array\",",
-                  "            \"items\": {",
-                  "                \"type\": \"object\",",
-                  "                \"required\": [\"name\", \"requiredParticipants\"],",
-                  "                \"properties\": {",
-                  "                    \"name\": { \"type\": \"string\" },",
-                  "                    \"requiredParticipants\": { \"type\": \"number\" }",
-                  "                },",
-                  "                \"additionalProperties\": false",
-                  "            }",
-                  "        },",
-                  "    },",
-                  "    \"additionalProperties\": false",
-                  "}",
-                  "",
-                  "pm.test(\"Status test\", function () {",
-                  "    pm.response.to.have.status(200);",
-                  "});",
-                  "",
-                  "pm.test(\"Content-Type is present\", function () {",
-                  "    pm.response.to.have.header(\"Content-Type\");",
-                  "});",
-                  "",
-                  "pm.test(\"Schema test\", function () {",
-                  "    pm.response.to.have.jsonSchema(schema);",
-                  "});"
-                ]
-              }
-            }
-          ]
-        },
-        {
-          "name": "Create",
-          "item": [
-            {
-              "name": "Create Comp",
-              "request": {
-                "method": "POST",
-                "header": [],
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\r\n    \"name\": \"CompTest\",\r\n    \"roles\": [\r\n        {\r\n            \"name\": \"Test\",\r\n            \"requiredParticipants\": 5\r\n        },\r\n        {\r\n            \"name\": \"Test2\",\r\n            \"requiredParticipants\": 3\r\n        }\r\n    ],\r\n    \"categories\": [\r\n        \"Niche\",\r\n        \"Generic\"\r\n    ]\r\n}",
-                  "options": {
-                    "raw": {
-                      "language": "json"
-                    }
-                  }
-                },
-                "url": {
-                  "raw": "{{baseUrl}}/comps",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["comps"]
-                }
-              },
-              "response": []
-            }
-          ],
-          "event": [
-            {
-              "listen": "prerequest",
-              "script": {
-                "type": "text/javascript",
-                "exec": [""]
-              }
-            },
-            {
-              "listen": "test",
-              "script": {
-                "type": "text/javascript",
-                "exec": [
-                  "const schema = {",
-                  "    \"type\": \"object\",",
-                  "    \"required\": [\"name\", \"_id\", \"categories\", \"roles\", \"__v\"],",
-                  "    \"properties\": {",
-                  "        \"name\": { \"type\": \"string\" },",
-                  "        \"categories\": { \"type\": \"array\", \"items\": { \"type\": \"string\" } },",
-                  "        \"roles\": {",
-                  "            \"type\": \"array\",",
-                  "            \"items\": {",
-                  "                \"type\": \"object\",",
-                  "                \"required\": [\"name\", \"requiredParticipants\"],",
-                  "                \"properties\": {",
-                  "                    \"name\": { \"type\": \"string\" },",
-                  "                    \"requiredParticipants\": { \"type\": \"number\" },",
-                  "                    \"_id\": { \"type\": \"string\" }",
-                  "                },",
-                  "                \"additionalProperties\": false",
-                  "            }",
-                  "        },",
-                  "        \"__v\": { \"type\": \"number\" },",
-                  "        \"_id\": { \"type\": \"string\" }",
-                  "    },",
-                  "    \"additionalProperties\": false",
-                  "}",
-                  "",
-                  "pm.test(\"Status test\", function () {",
-                  "    pm.response.to.have.status(201);",
-                  "});",
-                  "",
-                  "pm.test(\"Content-Type is present\", function () {",
-                  "    pm.response.to.have.header(\"Content-Type\");",
-                  "});",
-                  "",
-                  "pm.test(\"Schema test\", function () {",
-                  "    pm.response.to.have.jsonSchema(schema);",
-                  "});"
-                ]
-              }
-            }
-          ]
-        },
-        {
-          "name": "Delete",
-          "item": [
-            {
-              "name": "Delete Comp",
-              "request": {
-                "method": "DELETE",
-                "header": [],
-                "body": {
-                  "mode": "raw",
-                  "raw": "",
-                  "options": {
-                    "raw": {
-                      "language": "json"
-                    }
-                  }
-                },
-                "url": {
-                  "raw": "{{baseUrl}}/comps/CompTest",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["comps", "CompTest"]
-                }
-              },
-              "response": []
-            }
-          ]
-        },
-        {
-          "name": "Errors",
-          "item": [
-            {
-              "name": "Category Not Found",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"Status test\", function () {\r",
-                      "    pm.response.to.have.status(404);\r",
-                      "});"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{baseUrl}}/comps?categories=ThisCategoryDoesntExist",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["comps"],
-                  "query": [
-                    {
-                      "key": "categories",
-                      "value": "ThisCategoryDoesntExist"
-                    }
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "Bad Authentication",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"Status test\", function () {\r",
-                      "    pm.response.to.have.status(401);\r",
-                      "});"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "GET",
-                "header": [
-                  {
-                    "key": "Authorization",
-                    "value": "Bearer 123456789",
-                    "type": "text"
-                  }
-                ],
-                "url": {
-                  "raw": "{{baseUrl}}/comps",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["comps"]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "Nonexistent Comp",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"Status test\", function () {\r",
-                      "    pm.response.to.have.status(404);\r",
-                      "});"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{baseUrl}}/comps/DoubleChron",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["comps", "DoubleChron"]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "Existing Comp",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"Status test\", function () {\r",
-                      "    pm.response.to.have.status(422);\r",
-                      "});"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "POST",
-                "header": [],
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\r\n    \"name\": \"DoubleChrono\",\r\n    \"roles\": [\r\n        {\r\n            \"name\": \"DPS\",\r\n            \"requiredParticipants\": 8\r\n        },\r\n        {\r\n            \"name\": \"Chrono\",\r\n            \"requiredParticipants\": 2\r\n        }\r\n    ],\r\n    \"categories\": [\r\n        \"Generic\"\r\n    ]\r\n}",
-                  "options": {
-                    "raw": {
-                      "language": "json"
-                    }
-                  }
-                },
-                "url": {
-                  "raw": "{{baseUrl}}/comps",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["comps"]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "Comp With Bad Body",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"Status test\", function () {\r",
-                      "    pm.response.to.have.status(400);\r",
-                      "});"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "POST",
-                "header": [],
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\r\n    \"name\": \"CompTest\",\r\n    \"role\": [\r\n        {\r\n            \"name\": \"Test\",\r\n            \"requiredParticipants\": 5\r\n        },\r\n        {\r\n            \"name\": \"Test2\",\r\n            \"requiredParticipants\": 3\r\n        }\r\n    ],\r\n    \"categories\": [\r\n        \"Niche\",\r\n        \"Generic\"\r\n    ]\r\n}",
-                  "options": {
-                    "raw": {
-                      "language": "json"
-                    }
-                  }
-                },
-                "url": {
-                  "raw": "{{baseUrl}}/comps",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["comps"]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "Create Comp With No Roles",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"Status test\", function () {\r",
-                      "    pm.response.to.have.status(400);\r",
-                      "});"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "POST",
-                "header": [],
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\r\n    \"name\": \"CompTest\",\r\n    \"roles\": [],\r\n    \"categories\": [\r\n        \"Niche\",\r\n        \"Generic\"\r\n    ]\r\n}",
-                  "options": {
-                    "raw": {
-                      "language": "json"
-                    }
-                  }
-                },
-                "url": {
-                  "raw": "{{baseUrl}}/comps",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["comps"]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "Bad Authentication",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"Status test\", function () {\r",
-                      "    pm.response.to.have.status(401);\r",
-                      "});"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Authorization",
-                    "value": "Bearer 123456789",
-                    "type": "text"
-                  }
-                ],
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\r\n    \"name\": \"CompTest\",\r\n    \"roles\": [\r\n        {\r\n            \"name\": \"Test\",\r\n            \"requiredParticipants\": 5\r\n        },\r\n        {\r\n            \"name\": \"Test2\",\r\n            \"requiredParticipants\": 3\r\n        }\r\n    ],\r\n    \"categories\": [\r\n        \"Niche\",\r\n        \"Generic\"\r\n    ]\r\n}",
-                  "options": {
-                    "raw": {
-                      "language": "json"
-                    }
-                  }
-                },
-                "url": {
-                  "raw": "{{baseUrl}}/comps",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["comps"]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "Nonexistent Comp",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"Status test\", function () {\r",
-                      "    pm.response.to.have.status(404);\r",
-                      "});"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "DELETE",
-                "header": [],
-                "body": {
-                  "mode": "raw",
-                  "raw": "",
-                  "options": {
-                    "raw": {
-                      "language": "json"
-                    }
-                  }
-                },
-                "url": {
-                  "raw": "{{baseUrl}}/comps/DoubleChron",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["comps", "DoubleChron"]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "Bad Authentication",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"Status test\", function () {\r",
-                      "    pm.response.to.have.status(401);\r",
-                      "});"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "DELETE",
-                "header": [
-                  {
-                    "warning": "This is a duplicate header and will be overridden by the Authorization header generated by Postman.",
-                    "key": "Authorization",
-                    "value": "Bearer 123456789",
-                    "type": "text"
-                  }
-                ],
-                "body": {
-                  "mode": "raw",
-                  "raw": "",
-                  "options": {
-                    "raw": {
-                      "language": "json"
-                    }
-                  }
-                },
-                "url": {
-                  "raw": "{{baseUrl}}/comps/CompTest",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["comps", "CompTest"]
-                }
-              },
-              "response": []
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "name": "Categories",
-      "item": [
-        {
-          "name": "List",
-          "item": [
-            {
-              "name": "All Categories",
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{baseUrl}}/categories",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["categories"]
-                }
-              },
-              "response": []
-            }
-          ],
-          "event": [
-            {
-              "listen": "prerequest",
-              "script": {
-                "type": "text/javascript",
-                "exec": [""]
-              }
-            },
-            {
-              "listen": "test",
-              "script": {
-                "type": "text/javascript",
-                "exec": [
-                  "const schema = {",
-                  "    \"type\": \"array\",",
-                  "    \"required\": [\"name\"],",
-                  "    \"items\": {",
-                  "        \"type\": \"object\",",
-                  "        \"properties\": {",
-                  "            \"name\": { \"type\": \"string\" }",
-                  "        },",
-                  "        \"additionalProperties\": false",
-                  "    }",
-                  "}",
-                  "",
-                  "pm.test(\"Status test\", function () {",
-                  "    pm.response.to.have.status(200);",
-                  "});",
-                  "",
-                  "pm.test(\"Content-Type is present\", function () {",
-                  "    pm.response.to.have.header(\"Content-Type\");",
-                  "});",
-                  "",
-                  "pm.test(\"Schema test\", function () {",
-                  "    pm.response.to.have.jsonSchema(schema);",
-                  "});"
-                ]
-              }
-            }
-          ]
-        },
-        {
-          "name": "Get",
-          "item": [
-            {
-              "name": "Existent Category",
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{baseUrl}}/categories/Generic",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["categories", "Generic"]
-                }
-              },
-              "response": []
-            }
-          ],
-          "event": [
-            {
-              "listen": "prerequest",
-              "script": {
-                "type": "text/javascript",
-                "exec": [""]
-              }
-            },
-            {
-              "listen": "test",
-              "script": {
-                "type": "text/javascript",
-                "exec": [
-                  "const schema = {",
-                  "    \"type\": \"object\",",
-                  "    \"required\": [\"name\"],",
-                  "    \"properties\": {",
-                  "        \"name\": { \"type\": \"string\" }",
-                  "    },",
-                  "    \"additionalProperties\": false",
-                  "}",
-                  "",
-                  "pm.test(\"Status test\", function () {",
-                  "    pm.response.to.have.status(200);",
-                  "});",
-                  "",
-                  "pm.test(\"Content-Type is present\", function () {",
-                  "    pm.response.to.have.header(\"Content-Type\");",
-                  "});",
-                  "",
-                  "pm.test(\"Schema test\", function () {",
-                  "    pm.response.to.have.jsonSchema(schema);",
-                  "});"
-                ]
-              }
-            }
-          ]
-        },
-        {
-          "name": "Errors",
-          "item": [
-            {
-              "name": "Bad Authentication",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"Status test\", function () {\r",
-                      "    pm.response.to.have.status(401);\r",
-                      "});"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "GET",
-                "header": [
-                  {
-                    "key": "Authorization",
-                    "value": "Bearer 123456789",
-                    "type": "text"
-                  }
-                ],
-                "url": {
-                  "raw": "{{baseUrl}}/categories",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["categories"]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "Nonexistent Category",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"Status test\", function () {\r",
-                      "    pm.response.to.have.status(404);\r",
-                      "});"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{baseUrl}}/categories/Geeneric",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["categories", "Geeneric"]
-                }
-              },
-              "response": []
-            }
-          ]
-        }
-      ],
-      "event": [
-        {
-          "listen": "prerequest",
-          "script": {
-            "type": "text/javascript",
-            "exec": [""]
-          }
-        },
-        {
-          "listen": "test",
-          "script": {
-            "type": "text/javascript",
-            "exec": [""]
-          }
-        }
-      ]
-    },
-    {
-      "name": "Training Requests",
-      "item": [
-        {
-          "name": "List",
-          "item": [
-            {
-              "name": "All Training Requests",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [""],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{baseUrl}}/trainingrequests",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["trainingrequests"]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "Training Requests Page 1",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"Number of training requests test\", function () {\r",
-                      "    const responseJson = pm.response.json();\r",
-                      "    pm.expect(responseJson.length).to.eql(20);\r",
-                      "});"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{baseUrl}}/trainingrequests?page=1&pageSize=20",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["trainingrequests"],
-                  "query": [
-                    {
-                      "key": "page",
-                      "value": "1"
-                    },
-                    {
-                      "key": "pageSize",
-                      "value": "20"
-                    }
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "Keyword Search",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "const jsonData = pm.response.json()\r",
-                      "\r",
-                      "pm.test(\"All training request comments contain all of the specified strings\", () => {\r",
-                      "    _.each(jsonData, (item) => {\r",
-                      "        pm.request.url.getQueryString().toLowerCase().split(\"=\")[1].split(\",\").forEach(keyword => pm.expect(item.comment.toLowerCase()).to.contain(keyword))\r",
-                      "    })\r",
-                      "})"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{baseUrl}}/trainingrequests?keywords=dhuum,only",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["trainingrequests"],
-                  "query": [
-                    {
-                      "key": "keywords",
-                      "value": "dhuum,only"
-                    }
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "Only Active Training Requests",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "const jsonData = pm.response.json()\r",
-                      "\r",
-                      "pm.test(\"All training requests are active\", () => {\r",
-                      "    _.each(jsonData, (item) => {\r",
-                      "        pm.expect(item.active).to.eql(pm.request.url.getQueryString().split(\"=\")[1] == \"true\")\r",
-                      "    })\r",
-                      "})"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{baseUrl}}/trainingrequests?active=true",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["trainingrequests"],
-                  "query": [
-                    {
-                      "key": "active",
-                      "value": "true"
-                    }
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "Filter by Users",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [""],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{baseUrl}}/trainingrequests?users=Fattony%234209,Samunstein%235279,LoveSponge%239943",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["trainingrequests"],
-                  "query": [
-                    {
-                      "key": "users",
-                      "value": "Fattony%234209,Samunstein%235279,LoveSponge#9943"
-                    }
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "Filter by Wings",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "const jsonData = pm.response.json()\r",
-                      "\r",
-                      "pm.test(\"All training requests have one of the specified wings\", () => {\r",
-                      "    _.each(jsonData, (item) => {\r",
-                      "        const queryWings = pm.request.url.getQueryString().split(\"=\")[1].split(\",\").map(wing => Number.parseInt(wing));\r",
-                      "        const requestedWings = item.requestedWings;\r",
-                      "        const commonElements = queryWings.filter(wing => requestedWings.indexOf(wing) > -1);\r",
-                      "\r",
-                      "        pm.expect(commonElements.length).to.be.greaterThan(0);\r",
-                      "    })\r",
-                      "})"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{baseUrl}}/trainingrequests?wings=1,2,3",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["trainingrequests"],
-                  "query": [
-                    {
-                      "key": "wings",
-                      "value": "1,2,3"
-                    }
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "Filter by disabledReasons",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "const jsonData = pm.response.json()\r",
-                      "\r",
-                      "pm.test(\"All training request disabled reasons are one of the specified strings\", () => {\r",
-                      "    _.each(jsonData, (item) => {\r",
-                      "        pm.expect(item.disabledReason.toLowerCase()).to.be.oneOf(pm.request.url.getQueryString().toLowerCase().split(\"=\")[1].split(\",\"));\r",
-                      "    })\r",
-                      "})"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{baseUrl}}/trainingrequests?disabledReasons=None,Expired",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["trainingrequests"],
-                  "query": [
-                    {
-                      "key": "disabledReasons",
-                      "value": "None,Expired"
-                    }
-                  ]
-                }
-              },
-              "response": []
-            }
-          ],
-          "event": [
-            {
-              "listen": "prerequest",
-              "script": {
-                "type": "text/javascript",
-                "exec": [""]
-              }
-            },
-            {
-              "listen": "test",
-              "script": {
-                "type": "text/javascript",
-                "exec": [
-                  "const schema = {",
-                  "    \"type\": \"array\",",
-                  "    \"items\": {",
-                  "        \"type\": \"object\",",
-                  "        \"required\": [\"active\", \"requestedWings\", \"comment\", \"created\", \"edited\", \"disabledReason\", \"userId\"],",
-                  "        \"properties\": {",
-                  "            \"discordTag\": { \"type\": \"string\" },",
-                  "            \"active\": { \"type\": \"boolean\" },",
-                  "            \"requestedWings\": { \"type\": \"array\", \"items\": { \"type\": \"number\" }},",
-                  "            \"comment\": { \"type\": \"string\" },",
-                  "            \"created\": { \"type\": \"string\", \"pattern\": \"^(19|20)\\\\d\\\\d-(0[1-9]|1[012])-([012]\\\\d|3[01])T([01]\\\\d|2[0-3]):([0-5]\\\\d):([0-5]\\\\d)$\" },",
-                  "            \"edited\": { \"type\": \"string\", \"pattern\": \"^(19|20)\\\\d\\\\d-(0[1-9]|1[012])-([012]\\\\d|3[01])T([01]\\\\d|2[0-3]):([0-5]\\\\d):([0-5]\\\\d)$\" },",
-                  "            \"disabledReason\": {",
-                  "                \"type\": \"string\",",
-                  "                \"enum\": [",
-                  "                    \"None\",",
-                  "                    \"Manually by User\",",
-                  "                    \"Manually by Officer\",",
-                  "                    \"Fulfilled\",",
-                  "                    \"API Key Removed\",",
-                  "                    \"Invalid API Key\",",
-                  "                    \"No Longer Member\",",
-                  "                    \"Expired\"",
-                  "                ]",
-                  "            },",
-                  "            \"userId\": { \"type\": \"string\" }",
-                  "        },",
-                  "        \"additionalProperties\": false",
-                  "    }",
-                  "}",
-                  "",
-                  "pm.test(\"Status test\", function () {",
-                  "    pm.response.to.have.status(200);",
-                  "});",
-                  "",
-                  "pm.test(\"Content-Type is present\", function () {",
-                  "    pm.response.to.have.header(\"Content-Type\");",
-                  "});",
-                  "",
-                  "pm.test(\"Schema test\", function () {",
-                  "    pm.response.to.have.jsonSchema(schema);",
-                  "});"
-                ]
-              }
-            }
-          ]
-        },
-        {
-          "name": "Get",
-          "item": [
-            {
-              "name": "Existent Training Request",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [""],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{baseUrl}}/trainingrequests/218456492339101697",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["trainingrequests", "218456492339101697"]
-                }
-              },
-              "response": []
-            }
-          ],
-          "event": [
-            {
-              "listen": "prerequest",
-              "script": {
-                "type": "text/javascript",
-                "exec": [""]
-              }
-            },
-            {
-              "listen": "test",
-              "script": {
-                "type": "text/javascript",
-                "exec": [
-                  "const schema = {",
-                  "    \"type\": \"object\",",
-                  "    \"required\": [\"active\", \"requestedWings\", \"comment\", \"created\", \"edited\", \"disabledReason\", \"userId\", \"history\"],",
-                  "    \"properties\": {",
-                  "        \"discordTag\": { \"type\": \"string\" },",
-                  "        \"active\": { \"type\": \"boolean\" },",
-                  "        \"requestedWings\": { \"type\": \"array\", \"items\": { \"type\": \"number\" }},",
-                  "        \"comment\": { \"type\": \"string\" },",
-                  "        \"created\": { \"type\": \"string\", \"pattern\": \"^(19|20)\\\\d\\\\d-(0[1-9]|1[012])-([012]\\\\d|3[01])T([01]\\\\d|2[0-3]):([0-5]\\\\d):([0-5]\\\\d)$\" },",
-                  "        \"edited\": { \"type\": \"string\", \"pattern\": \"^(19|20)\\\\d\\\\d-(0[1-9]|1[012])-([012]\\\\d|3[01])T([01]\\\\d|2[0-3]):([0-5]\\\\d):([0-5]\\\\d)$\" },",
-                  "        \"disabledReason\": {",
-                  "            \"type\": \"string\",",
-                  "            \"enum\": [",
-                  "                \"None\",",
-                  "                \"Manually by User\",",
-                  "                \"Manually by Officer\",",
-                  "                \"Fulfilled\",",
-                  "                \"API Key Removed\",",
-                  "                \"Invalid API Key\",",
-                  "                \"No Longer Member\",",
-                  "                \"Expired\"",
-                  "            ]",
-                  "        },",
-                  "        \"userId\": { \"type\": \"string\" },",
-                  "        \"history\": {",
-                  "            \"type\": \"object\",",
-                  "            \"additionalProperties\": {",
-                  "                \"type\": \"object\",",
-                  "                \"properties\": {",
-                  "                    \"requested\": { \"type\": \"string\", \"pattern\": \"^(19|20)\\\\d\\\\d-(0[1-9]|1[012])-([012]\\\\d|3[01])T([01]\\\\d|2[0-3]):([0-5]\\\\d):([0-5]\\\\d)$\" },",
-                  "                    \"cleared\": { \"type\": \"string\", \"pattern\": \"^(19|20)\\\\d\\\\d-(0[1-9]|1[012])-([012]\\\\d|3[01])T([01]\\\\d|2[0-3]):([0-5]\\\\d):([0-5]\\\\d)$\" },",
-                  "                },",
-                  "                \"additionalProperties\": false",
-                  "            }",
-                  "        }",
-                  "    },",
-                  "    \"additionalProperties\": false",
-                  "}",
-                  "",
-                  "pm.test(\"Status test\", function () {",
-                  "    pm.response.to.have.status(200);",
-                  "});",
-                  "",
-                  "pm.test(\"Content-Type is present\", function () {",
-                  "    pm.response.to.have.header(\"Content-Type\");",
-                  "});",
-                  "",
-                  "pm.test(\"Schema test\", function () {",
-                  "    pm.response.to.have.jsonSchema(schema);",
-                  "});"
-                ]
-              }
-            }
-          ]
-        },
-        {
-          "name": "List CSV",
-          "item": [
-            {
-              "name": "All Training Requests as CSV",
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{baseUrl}}/trainingrequests?format=csv",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["trainingrequests"],
-                  "query": [
-                    {
-                      "key": "format",
-                      "value": "csv"
-                    }
-                  ]
-                }
-              },
-              "response": []
-            }
-          ],
-          "event": [
-            {
-              "listen": "prerequest",
-              "script": {
-                "type": "text/javascript",
-                "exec": [""]
-              }
-            },
-            {
-              "listen": "test",
-              "script": {
-                "type": "text/javascript",
-                "exec": [
-                  "pm.test(\"Status test\", function () {",
-                  "    pm.response.to.have.status(200);",
-                  "});",
-                  "",
-                  "pm.test(\"Content-Type is present\", function () {",
-                  "    pm.response.to.have.header(\"Content-Type\");",
-                  "});"
-                ]
-              }
-            }
-          ]
-        },
-        {
-          "name": "Errors",
-          "item": [
-            {
-              "name": "Wrong disabledReason",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"Status test\", function () {\r",
-                      "    pm.response.to.have.status(400);\r",
-                      "});"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{baseUrl}}/trainingrequests?active=no",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["trainingrequests"],
-                  "query": [
-                    {
-                      "key": "active",
-                      "value": "no"
-                    }
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "Wrong Active",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"Status test\", function () {\r",
-                      "    pm.response.to.have.status(400);\r",
-                      "});"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{baseUrl}}/trainingrequests?disabledReasons=ThisIsNotAReason",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["trainingrequests"],
-                  "query": [
-                    {
-                      "key": "disabledReasons",
-                      "value": "ThisIsNotAReason"
-                    }
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "Wings Aren't Numbers",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"Status test\", function () {\r",
-                      "    pm.response.to.have.status(400);\r",
-                      "});"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{baseUrl}}/trainingrequests?wings=one",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["trainingrequests"],
-                  "query": [
-                    {
-                      "key": "wings",
-                      "value": "one"
-                    }
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "Bad Authentication",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"Status test\", function () {\r",
-                      "    pm.response.to.have.status(401);\r",
-                      "});"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "GET",
-                "header": [
-                  {
-                    "key": "Authorization",
-                    "value": "Bearer 1234567890",
-                    "type": "text"
-                  }
-                ],
-                "url": {
-                  "raw": "{{baseUrl}}/trainingrequests",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["trainingrequests"]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "Page Without PageSize",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"Status test\", function () {\r",
-                      "    pm.response.to.have.status(400);\r",
-                      "});"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{baseUrl}}/trainingrequests?page=1",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["trainingrequests"],
-                  "query": [
-                    {
-                      "key": "page",
-                      "value": "1"
-                    }
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "PageSize Without Page",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"Status test\", function () {\r",
-                      "    pm.response.to.have.status(400);\r",
-                      "});"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{baseUrl}}/trainingrequests?pageSize=20",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["trainingrequests"],
-                  "query": [
-                    {
-                      "key": "pageSize",
-                      "value": "20"
-                    }
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "Wrong Format",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"Status test\", function () {\r",
-                      "    pm.response.to.have.status(400);\r",
-                      "});"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{baseUrl}}/trainingrequests?format=txt",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["trainingrequests"],
-                  "query": [
-                    {
-                      "key": "format",
-                      "value": "txt"
-                    }
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "Nonexistent Training Request",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"Status test\", function () {\r",
-                      "    pm.response.to.have.status(404);\r",
-                      "});"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{baseUrl}}/trainingrequests/111111111111111111111111",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["trainingrequests", "111111111111111111111111"]
-                }
-              },
-              "response": []
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "name": "Guild Options",
-      "item": [
-        {
-          "name": "Get",
-          "item": [
-            {
-              "name": "Get Guild Options",
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{baseUrl}}/guildoptions",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["guildoptions"]
-                }
-              },
-              "response": []
-            }
-          ],
-          "event": [
-            {
-              "listen": "prerequest",
-              "script": {
-                "type": "text/javascript",
-                "exec": [""]
-              }
-            },
-            {
-              "listen": "test",
-              "script": {
-                "type": "text/javascript",
-                "exec": [
-                  "const schema = {",
-                  "    \"type\": \"object\",",
-                  "    \"required\": [\"raidUnregisterNotificationTime\", \"raidReminderNotificationTime\", \"trainingRequestAutoSyncInterval\", \"trainingRequestInactiveDaysBeforeDisable\", \"raidAutoBroadcastTime\", \"commanderRoles\", \"officerRoles\"],",
-                  "    \"properties\": {",
-                  "        \"raidUnregisterNotificationTime\": { \"type\": \"number\" },",
-                  "        \"raidReminderNotificationTime\": { \"type\": \"number\" },",
-                  "        \"trainingRequestAutoSyncInterval\": {  \"type\": \"number\" },",
-                  "        \"trainingRequestInactiveDaysBeforeDisable\": { \"type\": \"number\" },",
-                  "        \"raidAutoBroadcastTime\": { \"type\": \"number\" },",
-                  "        \"commanderRoles\": { \"type\": \"array\", \"items\": { \"type\": \"string\" }},",
-                  "        \"officerRoles\": { \"type\": \"array\", \"items\": { \"type\": \"string\" }},",
-                  "        \"memberRoleId\": { \"type\": \"string\" },",
-                  "        \"guildApplicationsChannelId\": { \"type\": \"string\" },",
-                  "        \"raidCategoryId\": { \"type\": \"string\" },",
-                  "        \"raidDraftCategoryId\": { \"type\": \"string\" }",
-                  "    },",
-                  "    \"additionalProperties\": false",
-                  "}",
-                  "",
-                  "pm.test(\"Status test\", function () {",
-                  "    pm.response.to.have.status(200);",
-                  "});",
-                  "",
-                  "pm.test(\"Content-Type is present\", function () {",
-                  "    pm.response.to.have.header(\"Content-Type\");",
-                  "});",
-                  "",
-                  "pm.test(\"Schema test\", function () {",
-                  "    pm.response.to.have.jsonSchema(schema);",
-                  "});"
-                ]
-              }
-            }
-          ]
-        },
-        {
-          "name": "Errors",
-          "item": [
-            {
-              "name": "Bad Authentication",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "pm.test(\"Status test\", function () {\r",
-                      "    pm.response.to.have.status(401);\r",
-                      "});"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "GET",
-                "header": [
-                  {
-                    "warning": "This is a duplicate header and will be overridden by the Authorization header generated by Postman.",
-                    "key": "Authorization",
-                    "value": "Bearer 123456789",
-                    "type": "text"
-                  }
-                ],
-                "url": {
-                  "raw": "{{baseUrl}}/guildoptions",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["guildoptions"]
-                }
-              },
-              "response": []
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "name": "Other",
-      "item": [
-        {
-          "name": "GET /status",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "const schema = {\r",
-                  "    \"type\": \"object\",\r",
-                  "    \"required\": [\"timestamp\", \"processInfo\", \"apiInfo\", \"systemInfo\"],\r",
-                  "    \"items\": {\r",
-                  "        \"type\": \"object\",\r",
-                  "        \"properties\": {\r",
-                  "            \"timestamp\": { \"type\": \"number\" },\r",
-                  "            \"processInfo\": {\r",
-                  "                \"type\": \"object\",\r",
-                  "                \"required\": [\"uptime\", \"pid\", \"title\", \"environment\"],\r",
-                  "                \"properties\": {\r",
-                  "                    \"uptime\": { \"type\": \"string\" },\r",
-                  "                    \"pid\": { \"type\": \"number\" },\r",
-                  "                    \"title\": { \"type\": \"string\" },\r",
-                  "                    \"environment\": { \"type\": \"string\", \"enum\": [\"Debug\", \"Release\"] }\r",
-                  "                },\r",
-                  "                \"additionalProperties\": false\r",
-                  "            },\r",
-                  "            \"apiInfo\": {\r",
-                  "                \"type\": \"object\",\r",
-                  "                \"required\": [\"apiName\", \"apiVersion\", \"guildId\", \"gitVersionInfo\"],\r",
-                  "                \"properties\": {\r",
-                  "                    \"apiName\": { \"type\": \"string\" },\r",
-                  "                    \"apiVersion\": { \"type\": \"string\" },\r",
-                  "                    \"guildId\": { \"type\": \"string\" },\r",
-                  "                    \"gitVersionInfo\": {\r",
-                  "                        \"type\": \"object\",\r",
-                  "                        \"properties\": {\r",
-                  "                            \"branch\": { \"type\": \"string\" },\r",
-                  "                            \"commitId\": { \"type\": \"string\" }\r",
-                  "                        }\r",
-                  "                    }\r",
-                  "                },\r",
-                  "                \"additionalProperties\": false\r",
-                  "            },\r",
-                  "            \"systemInfo\": {\r",
-                  "                \"type\": \"object\",\r",
-                  "                \"required\": [\"platform\", \"type\", \"hostname\", \"release\", \"memory\", \"cores\"],\r",
-                  "                \"properties\": {\r",
-                  "                    \"platform\": { \"type\": \"string\" },\r",
-                  "                    \"type\": { \"type\": \"string\" },\r",
-                  "                    \"hostname\": { \"type\": \"string\" },\r",
-                  "                    \"release\": { \"type\": \"string\" },\r",
-                  "                    \"memory\": { \"type\": \"number\" },\r",
-                  "                    \"cores\": { \"type\": \"number\" }\r",
-                  "                },\r",
-                  "                \"additionalProperties\": false\r",
-                  "            },\r",
-                  "        },\r",
-                  "        \"additionalProperties\": false\r",
-                  "    }\r",
-                  "}\r",
-                  "\r",
-                  "pm.test(\"Status test\", function () {\r",
-                  "    pm.response.to.have.status(200);\r",
-                  "});\r",
-                  "\r",
-                  "pm.test(\"Content-Type is present\", function () {\r",
-                  "    pm.response.to.have.header(\"Content-Type\");\r",
-                  "});\r",
-                  "\r",
-                  "pm.test(\"Schema test\", function () {\r",
-                  "    pm.response.to.have.jsonSchema(schema);\r",
-                  "});"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "auth": {
-              "type": "noauth"
-            },
-            "method": "GET",
-            "header": [],
-            "url": {
-              "raw": "{{baseUrl}}/status",
-              "host": ["{{baseUrl}}"],
-              "path": ["status"]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "GET /stats",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test(\"Status test\", function () {\r",
-                  "    pm.response.to.have.status(200);\r",
-                  "});\r",
-                  "\r",
-                  "pm.test(\"Content-Type is present\", function () {\r",
-                  "    pm.response.to.have.header(\"Content-Type\");\r",
-                  "});"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "auth": {
-              "type": "noauth"
-            },
-            "method": "GET",
-            "header": [],
-            "url": {
-              "raw": "{{baseUrl}}/stats",
-              "host": ["{{baseUrl}}"],
-              "path": ["stats"]
-            }
-          },
-          "response": []
-        }
-      ]
-    },
-    {
-      "name": "Discord Auth",
-      "item": [
-        {
-          "name": "Post",
-          "item": [
-            {
-              "name": "Post Discord Auth",
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "POST",
-                "header": [],
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\r\n    \"code\": \"DISCORD_OAUTH2_CODE\"\r\n}",
-                  "options": {
-                    "raw": {
-                      "language": "json"
-                    }
-                  }
-                },
-                "url": {
-                  "raw": "{{baseUrl}}/discordauth",
-                  "host": ["{{baseUrl}}"],
-                  "path": ["discordauth"]
-                }
-              },
-              "response": []
-            }
-          ]
-        }
-      ]
-    }
-  ],
-  "auth": {
-    "type": "bearer",
-    "bearer": [
-      {
-        "key": "token",
-        "value": "{{rtiApiToken}}",
-        "type": "string"
-      }
-    ]
-  },
-  "event": [
-    {
-      "listen": "prerequest",
-      "script": {
-        "type": "text/javascript",
-        "exec": [""]
-      }
-    },
-    {
-      "listen": "test",
-      "script": {
-        "type": "text/javascript",
-        "exec": [""]
-      }
-    }
-  ]
+	"info": {
+		"_postman_id": "f75e1372-a24a-4d69-9591-88b3a0efe74c",
+		"name": "RTI API",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "10971105"
+	},
+	"item": [
+		{
+			"name": "Raids",
+			"item": [
+				{
+					"name": "List",
+					"item": [
+						{
+							"name": "All Raids",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/raids",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"raids"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Raids Page 1",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Number of raids test\", function () {\r",
+											"    const responseJson = pm.response.json();\r",
+											"    pm.expect(responseJson.length).to.eql(20);\r",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/raids?page=1&pageSize=20",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"raids"
+									],
+									"query": [
+										{
+											"key": "page",
+											"value": "1"
+										},
+										{
+											"key": "pageSize",
+											"value": "20"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Name Search",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"const jsonData = pm.response.json()\r",
+											"\r",
+											"pm.test(\"All raid names contain the specified string\", () => {\r",
+											"    _.each(jsonData, (item) => {\r",
+											"        pm.expect(item.name.toLowerCase()).to.contain(pm.request.url.getQueryString().split(\"=\")[1]);\r",
+											"    })\r",
+											"})"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/raids?name=continuation",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"raids"
+									],
+									"query": [
+										{
+											"key": "name",
+											"value": "continuation"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Search Participants",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/raids?participants=step%230,akronox%230",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"raids"
+									],
+									"query": [
+										{
+											"key": "participants",
+											"value": "step%230,akronox%230"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Search Reserves",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/raids?reserves=step%230",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"raids"
+									],
+									"query": [
+										{
+											"key": "reserves",
+											"value": "step%230"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Only Draft & Published Raids",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"const jsonData = pm.response.json()\r",
+											"\r",
+											"pm.test(\"All raids are either draft or published\", () => {\r",
+											"    _.each(jsonData, (item) => {\r",
+											"        pm.expect(item.status.toLowerCase()).to.be.oneOf(pm.request.url.getQueryString().toLowerCase().split(\"=\")[1].split(\",\"));\r",
+											"    })\r",
+											"})"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/raids?status=draft,published",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"raids"
+									],
+									"query": [
+										{
+											"key": "status",
+											"value": "draft,published"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Archived Raids With Comps",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"const jsonData = pm.response.json()\r",
+											"\r",
+											"pm.test(\"All raids have the specified leader\", () => {\r",
+											"    _.each(jsonData, (item) => {\r",
+											"        pm.expect(item.status.toLowerCase()).to.be.oneOf(pm.request.url.getQueryString().split(\"&\")[0].split(\"=\")[1].split(\",\"));\r",
+											"    })\r",
+											"})"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/raids?status=archived&comps=Dhuum-RR,SoullessHorror",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"raids"
+									],
+									"query": [
+										{
+											"key": "status",
+											"value": "archived"
+										},
+										{
+											"key": "comps",
+											"value": "Dhuum-RR,SoullessHorror"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Filter by Leader",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"const jsonData = pm.response.json()\r",
+											"\r",
+											"pm.test(\"All raids have the specified leader\", () => {\r",
+											"    _.each(jsonData, (item) => {\r",
+											"        pm.expect(item.leader).to.eql(pm.request.url.getQueryString().split(\"=\")[1].replace(\"%23\", \"#\"))\r",
+											"    })\r",
+											"})"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/raids?leader=step%230",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"raids"
+									],
+									"query": [
+										{
+											"key": "leader",
+											"value": "step%230"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Filter by Date",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"const jsonData = pm.response.json()\r",
+											"\r",
+											"pm.test(\"All raids are within the specified date range\", () => {\r",
+											"    _.each(jsonData, (item) => {\r",
+											"        pm.expect(Date.parse(item.startTime)).to.be.above(Date.parse(pm.request.url.query.get(\"dateFrom\")));\r",
+											"        pm.expect(Date.parse(item.endTime)).to.be.below(Date.parse(pm.request.url.query.get(\"dateTo\")));\r",
+											"    })\r",
+											"})"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/raids?dateFrom=2021-10-06T00:00:00&dateTo=2022-03-07T00:00:00",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"raids"
+									],
+									"query": [
+										{
+											"key": "dateFrom",
+											"value": "2021-10-06T00:00:00"
+										},
+										{
+											"key": "dateTo",
+											"value": "2022-03-07T00:00:00"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Show Participants",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"const jsonData = pm.response.json()\r",
+											"\r",
+											"pm.test(\"Participants field is present\", () => {\r",
+											"    _.each(jsonData, (item) => {\r",
+											"        pm.expect(Object.keys(item)).to.include(\"participants\")\r",
+											"    })\r",
+											"})"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/raids?page=1&pageSize=20&showParticipants=true&status=draft,published",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"raids"
+									],
+									"query": [
+										{
+											"key": "page",
+											"value": "1"
+										},
+										{
+											"key": "pageSize",
+											"value": "20"
+										},
+										{
+											"key": "showParticipants",
+											"value": "true"
+										},
+										{
+											"key": "status",
+											"value": "draft,published"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									"const schema = {",
+									"    \"type\": \"array\",",
+									"    \"items\": {",
+									"        \"type\": \"object\",",
+									"        \"required\": [\"name\", \"status\", \"startTime\", \"endTime\", \"id\"],",
+									"        \"properties\": {",
+									"            \"name\": { \"type\": \"string\" },",
+									"            \"status\": { \"type\": \"string\", \"enum\": [\"Archived\", \"Draft\", \"Published\"] },",
+									"            \"startTime\": { \"type\": \"string\", \"pattern\": \"^(19|20)\\\\d\\\\d-(0[1-9]|1[012])-([012]\\\\d|3[01])T([01]\\\\d|2[0-3]):([0-5]\\\\d):([0-5]\\\\d)$\" },",
+									"            \"endTime\": { \"type\": \"string\", \"pattern\": \"^(19|20)\\\\d\\\\d-(0[1-9]|1[012])-([012]\\\\d|3[01])T([01]\\\\d|2[0-3]):([0-5]\\\\d):([0-5]\\\\d)$\" },",
+									"            \"publishedDate\": { \"type\": \"string\", \"pattern\": \"^(19|20)\\\\d\\\\d-(0[1-9]|1[012])-([012]\\\\d|3[01])T([01]\\\\d|2[0-3]):([0-5]\\\\d):([0-5]\\\\d)$\" },",
+									"            \"leader\": { \"type\": \"string\" },",
+									"            \"comp\": { \"type\": \"string\" },",
+									"            \"participants\": { \"type\": \"array\", \"items\": { \"type\": \"string\" }},",
+									"            \"id\": { \"type\": \"string\" }",
+									"        },",
+									"        \"additionalProperties\": false",
+									"    }",
+									"}",
+									"",
+									"pm.test(\"Status test\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Content-Type is present\", function () {",
+									"    pm.response.to.have.header(\"Content-Type\");",
+									"});",
+									"",
+									"pm.test(\"Schema test\", function () {",
+									"    pm.response.to.have.jsonSchema(schema);",
+									"});"
+								]
+							}
+						}
+					]
+				},
+				{
+					"name": "Get",
+					"item": [
+						{
+							"name": "Existent Raid",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/raids/602711570e73df0012df74f9",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"raids",
+										"602711570e73df0012df74f9"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Raid with GW2 Names",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/raids/602711570e73df0012df74f9?names=gw2",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"raids",
+										"602711570e73df0012df74f9"
+									],
+									"query": [
+										{
+											"key": "names",
+											"value": "gw2"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Raid with Discord Names",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/raids/6027115a0e73df0012dfa185?names=discord",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"raids",
+										"6027115a0e73df0012dfa185"
+									],
+									"query": [
+										{
+											"key": "names",
+											"value": "discord"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									"const schema = {",
+									"    \"type\": \"object\",",
+									"    \"required\": [\"name\", \"status\", \"startTime\", \"endTime\", \"leader\", \"id\", \"participants\", \"reserves\"],",
+									"    \"properties\": {",
+									"        \"name\": { \"type\": \"string\" },",
+									"        \"description\": { \"type\": \"string\" },",
+									"        \"status\": { \"type\": \"string\", \"enum\": [\"Archived\", \"Draft\", \"Published\"] },",
+									"        \"startTime\": { \"type\": \"string\", \"pattern\": \"^(19|20)\\\\d\\\\d-(0[1-9]|1[012])-([012]\\\\d|3[01])T([01]\\\\d|2[0-3]):([0-5]\\\\d):([0-5]\\\\d)$\" },",
+									"        \"endTime\": { \"type\": \"string\", \"pattern\": \"^(19|20)\\\\d\\\\d-(0[1-9]|1[012])-([012]\\\\d|3[01])T([01]\\\\d|2[0-3]):([0-5]\\\\d):([0-5]\\\\d)$\" },",
+									"        \"publishedDate\": { \"type\": \"string\", \"pattern\": \"^(19|20)\\\\d\\\\d-(0[1-9]|1[012])-([012]\\\\d|3[01])T([01]\\\\d|2[0-3]):([0-5]\\\\d):([0-5]\\\\d)$\" },",
+									"        \"leader\": { \"type\": \"string\" },",
+									"        \"comp\": { \"type\": \"string\" },",
+									"        \"channelId\": { \"type\": \"string\" },",
+									"        \"participants\": {",
+									"            \"type\": \"array\",",
+									"            \"items\": {",
+									"                \"properties\": {",
+									"                    \"role\": { \"type\": \"string\" },",
+									"                    \"requiredParticipants\": { \"type\": \"number\" },",
+									"                    \"members\": { \"type\": \"array\", \"items\": { \"type\": [\"string\", \"null\"]}}",
+									"                },",
+									"                \"additionalProperties\": false",
+									"            }",
+									"        },",
+									"        \"reserves\": {",
+									"            \"type\": \"array\",",
+									"            \"items\": {",
+									"                \"properties\": {",
+									"                    \"role\": { \"type\": \"string\" },",
+									"                    \"requiredParticipants\": { \"type\": \"number\" },",
+									"                    \"members\": { \"type\": \"array\", \"items\": { \"type\": [\"string\", \"null\"]}}",
+									"                },",
+									"                \"additionalProperties\": false",
+									"            }",
+									"        },",
+									"        \"id\": { \"type\": \"string\" }",
+									"    },",
+									"    \"additionalProperties\": false",
+									"}",
+									"",
+									"pm.test(\"Status test\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Content-Type is present\", function () {",
+									"    pm.response.to.have.header(\"Content-Type\");",
+									"});",
+									"",
+									"pm.test(\"Schema test\", function () {",
+									"    pm.response.to.have.jsonSchema(schema);",
+									"});"
+								]
+							}
+						}
+					]
+				},
+				{
+					"name": "List CSV",
+					"item": [
+						{
+							"name": "All Raids as CSV",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/raids?format=csv",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"raids"
+									],
+									"query": [
+										{
+											"key": "format",
+											"value": "csv"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Published Raids as CSV",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/raids?format=csv&published=true",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"raids"
+									],
+									"query": [
+										{
+											"key": "format",
+											"value": "csv"
+										},
+										{
+											"key": "published",
+											"value": "true"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									"pm.test(\"Status test\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Content-Type is present\", function () {",
+									"    pm.response.to.have.header(\"Content-Type\");",
+									"});"
+								]
+							}
+						}
+					]
+				},
+				{
+					"name": "Errors",
+					"item": [
+						{
+							"name": "Wrong Status",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status test\", function () {\r",
+											"    pm.response.to.have.status(400);\r",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/raids?status=druft",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"raids"
+									],
+									"query": [
+										{
+											"key": "status",
+											"value": "druft"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Wrong Published",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status test\", function () {\r",
+											"    pm.response.to.have.status(400);\r",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/raids?pageSize=20",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"raids"
+									],
+									"query": [
+										{
+											"key": "pageSize",
+											"value": "20"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Bad Authentication",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status test\", function () {\r",
+											"    pm.response.to.have.status(401);\r",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "noauth"
+								},
+								"method": "GET",
+								"header": [
+									{
+										"key": "Authorization",
+										"value": "Bearer 1234567890",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{baseUrl}}/raids",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"raids"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Page Without PageSize",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status test\", function () {\r",
+											"    pm.response.to.have.status(400);\r",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/raids?page=1",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"raids"
+									],
+									"query": [
+										{
+											"key": "page",
+											"value": "1"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "PageSize Without Page",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status test\", function () {\r",
+											"    pm.response.to.have.status(400);\r",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/raids?pageSize=20",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"raids"
+									],
+									"query": [
+										{
+											"key": "pageSize",
+											"value": "20"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Wrong Format",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status test\", function () {\r",
+											"    pm.response.to.have.status(400);\r",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/raids?format=txt",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"raids"
+									],
+									"query": [
+										{
+											"key": "format",
+											"value": "txt"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Nonexistent Raid",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status test\", function () {\r",
+											"    pm.response.to.have.status(404);\r",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/raids/111111111111111111111111",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"raids",
+										"111111111111111111111111"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Wrong Date Format",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status test\", function () {\r",
+											"    pm.response.to.have.status(400);\r",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/raids?dateFrom=2021-10-06T00:00:00.000Z&dateTo=2022-03-07T00:00:00.000Z",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"raids"
+									],
+									"query": [
+										{
+											"key": "dateFrom",
+											"value": "2021-10-06T00:00:00.000Z"
+										},
+										{
+											"key": "dateTo",
+											"value": "2022-03-07T00:00:00.000Z"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "From Date > To Date",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status test\", function () {\r",
+											"    pm.response.to.have.status(400);\r",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/raids?dateFrom=2023-10-06T00:00:00&dateTo=2022-03-07T00:00:00",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"raids"
+									],
+									"query": [
+										{
+											"key": "dateFrom",
+											"value": "2023-10-06T00:00:00"
+										},
+										{
+											"key": "dateTo",
+											"value": "2022-03-07T00:00:00"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Members",
+			"item": [
+				{
+					"name": "List",
+					"item": [
+						{
+							"name": "All Members",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/members",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"members"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Members Page 1",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Number of members test\", function () {\r",
+											"    const responseJson = pm.response.json();\r",
+											"    pm.expect(responseJson.length).to.eql(20);\r",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/members?page=1&pageSize=20",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"members"
+									],
+									"query": [
+										{
+											"key": "page",
+											"value": "1"
+										},
+										{
+											"key": "pageSize",
+											"value": "20"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "gw2Name Search",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"const jsonData = pm.response.json()\r",
+											"\r",
+											"pm.test(\"All members contain the specified string\", () => {\r",
+											"    _.each(jsonData, (item) => {\r",
+											"        pm.expect(item.gw2Name.toLowerCase()).to.contain(pm.request.url.getQueryString().split(\"=\")[1].toLowerCase());\r",
+											"    })\r",
+											"})"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/members?gw2Name=Step",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"members"
+									],
+									"query": [
+										{
+											"key": "gw2Name",
+											"value": "Step"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "discordTag Search",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"const jsonData = pm.response.json()\r",
+											"\r",
+											"pm.test(\"All members contain the specified string\", () => {\r",
+											"    _.each(jsonData, (item) => {\r",
+											"        pm.expect(item.discordTag.toLowerCase()).to.contain(pm.request.url.getQueryString().split(\"=\")[1].toLowerCase());\r",
+											"    })\r",
+											"})"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/members?discordTag=step",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"members"
+									],
+									"query": [
+										{
+											"key": "discordTag",
+											"value": "step"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Filter by Approver",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"const jsonData = pm.response.json()\r",
+											"\r",
+											"pm.test(\"All members have the specified approver\", () => {\r",
+											"    _.each(jsonData, (item) => {\r",
+											"        pm.expect(item.approver).to.eql(pm.request.url.getQueryString().split(\"=\")[1].replace(\"%23\", \"#\"))\r",
+											"    })\r",
+											"})"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/members?approver=step%230",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"members"
+									],
+									"query": [
+										{
+											"key": "approver",
+											"value": "step%230"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Only Unbanned Members",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"const jsonData = pm.response.json()\r",
+											"\r",
+											"pm.test(\"All members are unbanned\", () => {\r",
+											"    _.each(jsonData, (item) => {\r",
+											"        pm.expect(item.banned).to.eql(pm.request.url.getQueryString().split(\"=\")[1] == \"true\")\r",
+											"    })\r",
+											"})"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/members?banned=false",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"members"
+									],
+									"query": [
+										{
+											"key": "banned",
+											"value": "false"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									"const schema = {",
+									"    \"type\": \"array\",",
+									"    \"items\": {",
+									"        \"type\": \"object\",",
+									"        \"required\": [\"gw2Name\", \"approver\", \"userId\", \"banned\"],",
+									"        \"properties\": {",
+									"            \"gw2Name\": { \"type\": \"string\" },",
+									"            \"discordName\": { \"type\": \"string\" },",
+									"            \"discordTag\": { \"type\": \"string\" },",
+									"            \"approver\": { \"type\": \"string\" },",
+									"            \"userId\": { \"type\": \"string\" },",
+									"            \"banned\": { \"type\": \"boolean\" }",
+									"        },",
+									"        \"additionalProperties\": false",
+									"    }",
+									"}",
+									"",
+									"pm.test(\"Status test\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Content-Type is present\", function () {",
+									"    pm.response.to.have.header(\"Content-Type\");",
+									"});",
+									"",
+									"pm.test(\"Schema test\", function () {",
+									"    pm.response.to.have.jsonSchema(schema);",
+									"});"
+								]
+							}
+						}
+					]
+				},
+				{
+					"name": "Get",
+					"item": [
+						{
+							"name": "Existent Member",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/members/82136625345200128",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"members",
+										"82136625345200128"
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									"const schema = {",
+									"    \"type\": \"object\",",
+									"    \"required\": [\"gw2Name\", \"discordName\", \"discordTag\", \"approver\", \"userId\", \"banned\"],",
+									"    \"properties\": {",
+									"        \"gw2Name\": { \"type\": \"string\" },",
+									"        \"discordName\": { \"type\": \"string\" },",
+									"        \"discordTag\": { \"type\": \"string\" },",
+									"        \"approver\": { \"type\": \"string\" },",
+									"        \"userId\": { \"type\": \"string\" },",
+									"        \"banned\": { \"type\": \"boolean\" }",
+									"    },",
+									"    \"additionalProperties\": false",
+									"}",
+									"",
+									"pm.test(\"Status test\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Content-Type is present\", function () {",
+									"    pm.response.to.have.header(\"Content-Type\");",
+									"});",
+									"",
+									"pm.test(\"Schema test\", function () {",
+									"    pm.response.to.have.jsonSchema(schema);",
+									"});"
+								]
+							}
+						}
+					]
+				},
+				{
+					"name": "List CSV",
+					"item": [
+						{
+							"name": "All Members as CSV",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/members?format=csv",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"members"
+									],
+									"query": [
+										{
+											"key": "format",
+											"value": "csv"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									"pm.test(\"Status test\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Content-Type is present\", function () {",
+									"    pm.response.to.have.header(\"Content-Type\");",
+									"});"
+								]
+							}
+						}
+					]
+				},
+				{
+					"name": "Errors",
+					"item": [
+						{
+							"name": "Approver Not Found",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status test\", function () {\r",
+											"    pm.response.to.have.status(404);\r",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/members?approver=AbrahamLincoln",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"members"
+									],
+									"query": [
+										{
+											"key": "approver",
+											"value": "AbrahamLincoln"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Wrong Banned",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status test\", function () {\r",
+											"    pm.response.to.have.status(400);\r",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/members?banned=yes",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"members"
+									],
+									"query": [
+										{
+											"key": "banned",
+											"value": "yes"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Bad Authentication",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status test\", function () {\r",
+											"    pm.response.to.have.status(401);\r",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "noauth"
+								},
+								"method": "GET",
+								"header": [
+									{
+										"key": "Authorization",
+										"value": "Bearer 123456789",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{baseUrl}}/members",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"members"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Page Without PageSize",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status test\", function () {\r",
+											"    pm.response.to.have.status(400);\r",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/members?pageSize=20",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"members"
+									],
+									"query": [
+										{
+											"key": "pageSize",
+											"value": "20"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "PageSize Without Page",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status test\", function () {\r",
+											"    pm.response.to.have.status(400);\r",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/members?page=1",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"members"
+									],
+									"query": [
+										{
+											"key": "page",
+											"value": "1"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Wrong Format",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status test\", function () {\r",
+											"    pm.response.to.have.status(400);\r",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/members?format=txt",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"members"
+									],
+									"query": [
+										{
+											"key": "format",
+											"value": "txt"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Nonexistent Member",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status test\", function () {\r",
+											"    pm.response.to.have.status(404);\r",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/members/11111111111111111",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"members",
+										"11111111111111111"
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Comps",
+			"item": [
+				{
+					"name": "List",
+					"item": [
+						{
+							"name": "All Comps",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/comps",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"comps"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "By Categories",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"const jsonData = pm.response.json()\r",
+											"\r",
+											"pm.test(\"All comps have one of the specified categories\", () => {\r",
+											"    const queryCategoriesList = pm.request.url.getQueryString().split(\"=\")[1].replace(\"%20\", \" \").toLowerCase().split(\",\");\r",
+											"    _.each(jsonData, (item) => {\r",
+											"        const itemCategoriesList = item.categories.map(category => category.toLowerCase());\r",
+											"        const filteredList = queryCategoriesList.filter(category => itemCategoriesList.includes(category));\r",
+											"        pm.expect(filteredList.length).to.be.greaterThan(0);\r",
+											"    })\r",
+											"})"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/comps?categories=Generic,Wing%201",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"comps"
+									],
+									"query": [
+										{
+											"key": "categories",
+											"value": "Generic,Wing%201"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									"const schema = {",
+									"    \"type\": \"array\",",
+									"    \"items\": {",
+									"        \"type\": \"object\",",
+									"        \"required\": [\"name\", \"categories\", \"roles\"],",
+									"        \"properties\": {",
+									"            \"name\": { \"type\": \"string\" },",
+									"            \"categories\": { \"type\": \"array\", \"items\": { \"type\": \"string\" } },",
+									"            \"roles\": {",
+									"                \"type\": \"array\",",
+									"                \"items\": {",
+									"                    \"type\": \"object\",",
+									"                    \"required\": [\"name\", \"requiredParticipants\"],",
+									"                    \"properties\": {",
+									"                        \"name\": { \"type\": \"string\" },",
+									"                        \"requiredParticipants\": { \"type\": \"number\" }",
+									"                    },",
+									"                    \"additionalProperties\": false",
+									"                }",
+									"            },",
+									"        },",
+									"        \"additionalProperties\": false",
+									"    }",
+									"}",
+									"",
+									"pm.test(\"Status test\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Content-Type is present\", function () {",
+									"    pm.response.to.have.header(\"Content-Type\");",
+									"});",
+									"",
+									"pm.test(\"Schema test\", function () {",
+									"    pm.response.to.have.jsonSchema(schema);",
+									"});"
+								]
+							}
+						}
+					]
+				},
+				{
+					"name": "Get",
+					"item": [
+						{
+							"name": "Existent Comp",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/comps/DoubleChrono",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"comps",
+										"DoubleChrono"
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									"const schema = {",
+									"    \"type\": \"object\",",
+									"    \"required\": [\"name\", \"categories\", \"roles\"],",
+									"    \"properties\": {",
+									"        \"name\": { \"type\": \"string\" },",
+									"        \"categories\": { \"type\": \"array\", \"items\": { \"type\": \"string\" } },",
+									"        \"roles\": {",
+									"            \"type\": \"array\",",
+									"            \"items\": {",
+									"                \"type\": \"object\",",
+									"                \"required\": [\"name\", \"requiredParticipants\"],",
+									"                \"properties\": {",
+									"                    \"name\": { \"type\": \"string\" },",
+									"                    \"requiredParticipants\": { \"type\": \"number\" }",
+									"                },",
+									"                \"additionalProperties\": false",
+									"            }",
+									"        },",
+									"    },",
+									"    \"additionalProperties\": false",
+									"}",
+									"",
+									"pm.test(\"Status test\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Content-Type is present\", function () {",
+									"    pm.response.to.have.header(\"Content-Type\");",
+									"});",
+									"",
+									"pm.test(\"Schema test\", function () {",
+									"    pm.response.to.have.jsonSchema(schema);",
+									"});"
+								]
+							}
+						}
+					]
+				},
+				{
+					"name": "Create",
+					"item": [
+						{
+							"name": "Create Comp",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n    \"name\": \"CompTest\",\r\n    \"roles\": [\r\n        {\r\n            \"name\": \"Test\",\r\n            \"requiredParticipants\": 5\r\n        },\r\n        {\r\n            \"name\": \"Test2\",\r\n            \"requiredParticipants\": 3\r\n        }\r\n    ],\r\n    \"categories\": [\r\n        \"Niche\",\r\n        \"Generic\"\r\n    ]\r\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/comps",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"comps"
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									"const schema = {",
+									"    \"type\": \"object\",",
+									"    \"required\": [\"name\", \"_id\", \"categories\", \"roles\", \"__v\"],",
+									"    \"properties\": {",
+									"        \"name\": { \"type\": \"string\" },",
+									"        \"categories\": { \"type\": \"array\", \"items\": { \"type\": \"string\" } },",
+									"        \"roles\": {",
+									"            \"type\": \"array\",",
+									"            \"items\": {",
+									"                \"type\": \"object\",",
+									"                \"required\": [\"name\", \"requiredParticipants\"],",
+									"                \"properties\": {",
+									"                    \"name\": { \"type\": \"string\" },",
+									"                    \"requiredParticipants\": { \"type\": \"number\" },",
+									"                    \"_id\": { \"type\": \"string\" }",
+									"                },",
+									"                \"additionalProperties\": false",
+									"            }",
+									"        },",
+									"        \"__v\": { \"type\": \"number\" },",
+									"        \"_id\": { \"type\": \"string\" }",
+									"    },",
+									"    \"additionalProperties\": false",
+									"}",
+									"",
+									"pm.test(\"Status test\", function () {",
+									"    pm.response.to.have.status(201);",
+									"});",
+									"",
+									"pm.test(\"Content-Type is present\", function () {",
+									"    pm.response.to.have.header(\"Content-Type\");",
+									"});",
+									"",
+									"pm.test(\"Schema test\", function () {",
+									"    pm.response.to.have.jsonSchema(schema);",
+									"});"
+								]
+							}
+						}
+					]
+				},
+				{
+					"name": "Delete",
+					"item": [
+						{
+							"name": "Delete Comp",
+							"request": {
+								"method": "DELETE",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/comps/CompTest",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"comps",
+										"CompTest"
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "Errors",
+					"item": [
+						{
+							"name": "Category Not Found",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status test\", function () {\r",
+											"    pm.response.to.have.status(404);\r",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/comps?categories=ThisCategoryDoesntExist",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"comps"
+									],
+									"query": [
+										{
+											"key": "categories",
+											"value": "ThisCategoryDoesntExist"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Bad Authentication",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status test\", function () {\r",
+											"    pm.response.to.have.status(401);\r",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "noauth"
+								},
+								"method": "GET",
+								"header": [
+									{
+										"key": "Authorization",
+										"value": "Bearer 123456789",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{baseUrl}}/comps",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"comps"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Nonexistent Comp",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status test\", function () {\r",
+											"    pm.response.to.have.status(404);\r",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/comps/DoubleChron",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"comps",
+										"DoubleChron"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Existing Comp",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status test\", function () {\r",
+											"    pm.response.to.have.status(422);\r",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n    \"name\": \"DoubleChrono\",\r\n    \"roles\": [\r\n        {\r\n            \"name\": \"DPS\",\r\n            \"requiredParticipants\": 8\r\n        },\r\n        {\r\n            \"name\": \"Chrono\",\r\n            \"requiredParticipants\": 2\r\n        }\r\n    ],\r\n    \"categories\": [\r\n        \"Generic\"\r\n    ]\r\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/comps",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"comps"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Comp With Bad Body",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status test\", function () {\r",
+											"    pm.response.to.have.status(400);\r",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n    \"name\": \"CompTest\",\r\n    \"role\": [\r\n        {\r\n            \"name\": \"Test\",\r\n            \"requiredParticipants\": 5\r\n        },\r\n        {\r\n            \"name\": \"Test2\",\r\n            \"requiredParticipants\": 3\r\n        }\r\n    ],\r\n    \"categories\": [\r\n        \"Niche\",\r\n        \"Generic\"\r\n    ]\r\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/comps",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"comps"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Create Comp With No Roles",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status test\", function () {\r",
+											"    pm.response.to.have.status(400);\r",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n    \"name\": \"CompTest\",\r\n    \"roles\": [],\r\n    \"categories\": [\r\n        \"Niche\",\r\n        \"Generic\"\r\n    ]\r\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/comps",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"comps"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Bad Authentication",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status test\", function () {\r",
+											"    pm.response.to.have.status(401);\r",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "noauth"
+								},
+								"method": "POST",
+								"header": [
+									{
+										"key": "Authorization",
+										"value": "Bearer 123456789",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n    \"name\": \"CompTest\",\r\n    \"roles\": [\r\n        {\r\n            \"name\": \"Test\",\r\n            \"requiredParticipants\": 5\r\n        },\r\n        {\r\n            \"name\": \"Test2\",\r\n            \"requiredParticipants\": 3\r\n        }\r\n    ],\r\n    \"categories\": [\r\n        \"Niche\",\r\n        \"Generic\"\r\n    ]\r\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/comps",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"comps"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Nonexistent Comp",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status test\", function () {\r",
+											"    pm.response.to.have.status(404);\r",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/comps/DoubleChron",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"comps",
+										"DoubleChron"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Bad Authentication",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status test\", function () {\r",
+											"    pm.response.to.have.status(401);\r",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "noauth"
+								},
+								"method": "DELETE",
+								"header": [
+									{
+										"warning": "This is a duplicate header and will be overridden by the Authorization header generated by Postman.",
+										"key": "Authorization",
+										"value": "Bearer 123456789",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/comps/CompTest",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"comps",
+										"CompTest"
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Categories",
+			"item": [
+				{
+					"name": "List",
+					"item": [
+						{
+							"name": "All Categories",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/categories",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"categories"
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									"const schema = {",
+									"    \"type\": \"array\",",
+									"    \"required\": [\"name\"],",
+									"    \"items\": {",
+									"        \"type\": \"object\",",
+									"        \"properties\": {",
+									"            \"name\": { \"type\": \"string\" }",
+									"        },",
+									"        \"additionalProperties\": false",
+									"    }",
+									"}",
+									"",
+									"pm.test(\"Status test\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Content-Type is present\", function () {",
+									"    pm.response.to.have.header(\"Content-Type\");",
+									"});",
+									"",
+									"pm.test(\"Schema test\", function () {",
+									"    pm.response.to.have.jsonSchema(schema);",
+									"});"
+								]
+							}
+						}
+					]
+				},
+				{
+					"name": "Get",
+					"item": [
+						{
+							"name": "Existent Category",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/categories/Generic",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"categories",
+										"Generic"
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									"const schema = {",
+									"    \"type\": \"object\",",
+									"    \"required\": [\"name\"],",
+									"    \"properties\": {",
+									"        \"name\": { \"type\": \"string\" }",
+									"    },",
+									"    \"additionalProperties\": false",
+									"}",
+									"",
+									"pm.test(\"Status test\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Content-Type is present\", function () {",
+									"    pm.response.to.have.header(\"Content-Type\");",
+									"});",
+									"",
+									"pm.test(\"Schema test\", function () {",
+									"    pm.response.to.have.jsonSchema(schema);",
+									"});"
+								]
+							}
+						}
+					]
+				},
+				{
+					"name": "Errors",
+					"item": [
+						{
+							"name": "Bad Authentication",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status test\", function () {\r",
+											"    pm.response.to.have.status(401);\r",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "noauth"
+								},
+								"method": "GET",
+								"header": [
+									{
+										"key": "Authorization",
+										"value": "Bearer 123456789",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{baseUrl}}/categories",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"categories"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Nonexistent Category",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status test\", function () {\r",
+											"    pm.response.to.have.status(404);\r",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/categories/Geeneric",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"categories",
+										"Geeneric"
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				}
+			],
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				}
+			]
+		},
+		{
+			"name": "Training Requests",
+			"item": [
+				{
+					"name": "List",
+					"item": [
+						{
+							"name": "All Training Requests",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/trainingrequests",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"trainingrequests"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Training Requests Page 1",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Number of training requests test\", function () {\r",
+											"    const responseJson = pm.response.json();\r",
+											"    pm.expect(responseJson.length).to.eql(20);\r",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/trainingrequests?page=1&pageSize=20",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"trainingrequests"
+									],
+									"query": [
+										{
+											"key": "page",
+											"value": "1"
+										},
+										{
+											"key": "pageSize",
+											"value": "20"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Keyword Search",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"const jsonData = pm.response.json()\r",
+											"\r",
+											"pm.test(\"All training request comments contain all of the specified strings\", () => {\r",
+											"    _.each(jsonData, (item) => {\r",
+											"        pm.request.url.getQueryString().toLowerCase().split(\"=\")[1].split(\",\").forEach(keyword => pm.expect(item.comment.toLowerCase()).to.contain(keyword))\r",
+											"    })\r",
+											"})"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/trainingrequests?keywords=dhuum,only",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"trainingrequests"
+									],
+									"query": [
+										{
+											"key": "keywords",
+											"value": "dhuum,only"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Only Active Training Requests",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"const jsonData = pm.response.json()\r",
+											"\r",
+											"pm.test(\"All training requests are active\", () => {\r",
+											"    _.each(jsonData, (item) => {\r",
+											"        pm.expect(item.active).to.eql(pm.request.url.getQueryString().split(\"=\")[1] == \"true\")\r",
+											"    })\r",
+											"})"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/trainingrequests?active=true",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"trainingrequests"
+									],
+									"query": [
+										{
+											"key": "active",
+											"value": "true"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Filter by Users",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/trainingrequests?users=Fattony%234209,Samunstein%235279,LoveSponge%239943",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"trainingrequests"
+									],
+									"query": [
+										{
+											"key": "users",
+											"value": "Fattony%234209,Samunstein%235279,LoveSponge#9943"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Filter by Wings",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"const jsonData = pm.response.json()\r",
+											"\r",
+											"pm.test(\"All training requests have one of the specified wings\", () => {\r",
+											"    _.each(jsonData, (item) => {\r",
+											"        const queryWings = pm.request.url.getQueryString().split(\"=\")[1].split(\",\").map(wing => Number.parseInt(wing));\r",
+											"        const requestedWings = item.requestedWings;\r",
+											"        const commonElements = queryWings.filter(wing => requestedWings.indexOf(wing) > -1);\r",
+											"\r",
+											"        pm.expect(commonElements.length).to.be.greaterThan(0);\r",
+											"    })\r",
+											"})"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/trainingrequests?wings=1,2,3",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"trainingrequests"
+									],
+									"query": [
+										{
+											"key": "wings",
+											"value": "1,2,3"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Filter by disabledReasons",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"const jsonData = pm.response.json()\r",
+											"\r",
+											"pm.test(\"All training request disabled reasons are one of the specified strings\", () => {\r",
+											"    _.each(jsonData, (item) => {\r",
+											"        pm.expect(item.disabledReason.toLowerCase()).to.be.oneOf(pm.request.url.getQueryString().toLowerCase().split(\"=\")[1].split(\",\"));\r",
+											"    })\r",
+											"})"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/trainingrequests?disabledReasons=None,Expired",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"trainingrequests"
+									],
+									"query": [
+										{
+											"key": "disabledReasons",
+											"value": "None,Expired"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									"const schema = {",
+									"    \"type\": \"array\",",
+									"    \"items\": {",
+									"        \"type\": \"object\",",
+									"        \"required\": [\"active\", \"requestedWings\", \"comment\", \"created\", \"edited\", \"disabledReason\", \"userId\"],",
+									"        \"properties\": {",
+									"            \"discordTag\": { \"type\": \"string\" },",
+									"            \"active\": { \"type\": \"boolean\" },",
+									"            \"requestedWings\": { \"type\": \"array\", \"items\": { \"type\": \"number\" }},",
+									"            \"comment\": { \"type\": \"string\" },",
+									"            \"created\": { \"type\": \"string\", \"pattern\": \"^(19|20)\\\\d\\\\d-(0[1-9]|1[012])-([012]\\\\d|3[01])T([01]\\\\d|2[0-3]):([0-5]\\\\d):([0-5]\\\\d)$\" },",
+									"            \"edited\": { \"type\": \"string\", \"pattern\": \"^(19|20)\\\\d\\\\d-(0[1-9]|1[012])-([012]\\\\d|3[01])T([01]\\\\d|2[0-3]):([0-5]\\\\d):([0-5]\\\\d)$\" },",
+									"            \"disabledReason\": {",
+									"                \"type\": \"string\",",
+									"                \"enum\": [",
+									"                    \"None\",",
+									"                    \"Manually by User\",",
+									"                    \"Manually by Officer\",",
+									"                    \"Fulfilled\",",
+									"                    \"API Key Removed\",",
+									"                    \"Invalid API Key\",",
+									"                    \"No Longer Member\",",
+									"                    \"Expired\"",
+									"                ]",
+									"            },",
+									"            \"userId\": { \"type\": \"string\" }",
+									"        },",
+									"        \"additionalProperties\": false",
+									"    }",
+									"}",
+									"",
+									"pm.test(\"Status test\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Content-Type is present\", function () {",
+									"    pm.response.to.have.header(\"Content-Type\");",
+									"});",
+									"",
+									"pm.test(\"Schema test\", function () {",
+									"    pm.response.to.have.jsonSchema(schema);",
+									"});"
+								]
+							}
+						}
+					]
+				},
+				{
+					"name": "Get",
+					"item": [
+						{
+							"name": "Existent Training Request",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/trainingrequests/218456492339101697",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"trainingrequests",
+										"218456492339101697"
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									"const schema = {",
+									"    \"type\": \"object\",",
+									"    \"required\": [\"active\", \"requestedWings\", \"comment\", \"created\", \"edited\", \"disabledReason\", \"userId\", \"history\"],",
+									"    \"properties\": {",
+									"        \"discordTag\": { \"type\": \"string\" },",
+									"        \"active\": { \"type\": \"boolean\" },",
+									"        \"requestedWings\": { \"type\": \"array\", \"items\": { \"type\": \"number\" }},",
+									"        \"comment\": { \"type\": \"string\" },",
+									"        \"created\": { \"type\": \"string\", \"pattern\": \"^(19|20)\\\\d\\\\d-(0[1-9]|1[012])-([012]\\\\d|3[01])T([01]\\\\d|2[0-3]):([0-5]\\\\d):([0-5]\\\\d)$\" },",
+									"        \"edited\": { \"type\": \"string\", \"pattern\": \"^(19|20)\\\\d\\\\d-(0[1-9]|1[012])-([012]\\\\d|3[01])T([01]\\\\d|2[0-3]):([0-5]\\\\d):([0-5]\\\\d)$\" },",
+									"        \"disabledReason\": {",
+									"            \"type\": \"string\",",
+									"            \"enum\": [",
+									"                \"None\",",
+									"                \"Manually by User\",",
+									"                \"Manually by Officer\",",
+									"                \"Fulfilled\",",
+									"                \"API Key Removed\",",
+									"                \"Invalid API Key\",",
+									"                \"No Longer Member\",",
+									"                \"Expired\"",
+									"            ]",
+									"        },",
+									"        \"userId\": { \"type\": \"string\" },",
+									"        \"history\": {",
+									"            \"type\": \"object\",",
+									"            \"additionalProperties\": {",
+									"                \"type\": \"object\",",
+									"                \"properties\": {",
+									"                    \"requested\": { \"type\": \"string\", \"pattern\": \"^(19|20)\\\\d\\\\d-(0[1-9]|1[012])-([012]\\\\d|3[01])T([01]\\\\d|2[0-3]):([0-5]\\\\d):([0-5]\\\\d)$\" },",
+									"                    \"cleared\": { \"type\": \"string\", \"pattern\": \"^(19|20)\\\\d\\\\d-(0[1-9]|1[012])-([012]\\\\d|3[01])T([01]\\\\d|2[0-3]):([0-5]\\\\d):([0-5]\\\\d)$\" },",
+									"                },",
+									"                \"additionalProperties\": false",
+									"            }",
+									"        }",
+									"    },",
+									"    \"additionalProperties\": false",
+									"}",
+									"",
+									"pm.test(\"Status test\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Content-Type is present\", function () {",
+									"    pm.response.to.have.header(\"Content-Type\");",
+									"});",
+									"",
+									"pm.test(\"Schema test\", function () {",
+									"    pm.response.to.have.jsonSchema(schema);",
+									"});"
+								]
+							}
+						}
+					]
+				},
+				{
+					"name": "List CSV",
+					"item": [
+						{
+							"name": "All Training Requests as CSV",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/trainingrequests?format=csv",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"trainingrequests"
+									],
+									"query": [
+										{
+											"key": "format",
+											"value": "csv"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									"pm.test(\"Status test\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Content-Type is present\", function () {",
+									"    pm.response.to.have.header(\"Content-Type\");",
+									"});"
+								]
+							}
+						}
+					]
+				},
+				{
+					"name": "Errors",
+					"item": [
+						{
+							"name": "Wrong disabledReason",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status test\", function () {\r",
+											"    pm.response.to.have.status(400);\r",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/trainingrequests?active=no",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"trainingrequests"
+									],
+									"query": [
+										{
+											"key": "active",
+											"value": "no"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Wrong Active",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status test\", function () {\r",
+											"    pm.response.to.have.status(400);\r",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/trainingrequests?disabledReasons=ThisIsNotAReason",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"trainingrequests"
+									],
+									"query": [
+										{
+											"key": "disabledReasons",
+											"value": "ThisIsNotAReason"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Wings Aren't Numbers",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status test\", function () {\r",
+											"    pm.response.to.have.status(400);\r",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/trainingrequests?wings=one",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"trainingrequests"
+									],
+									"query": [
+										{
+											"key": "wings",
+											"value": "one"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Bad Authentication",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status test\", function () {\r",
+											"    pm.response.to.have.status(401);\r",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "noauth"
+								},
+								"method": "GET",
+								"header": [
+									{
+										"key": "Authorization",
+										"value": "Bearer 1234567890",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{baseUrl}}/trainingrequests",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"trainingrequests"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Page Without PageSize",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status test\", function () {\r",
+											"    pm.response.to.have.status(400);\r",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/trainingrequests?page=1",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"trainingrequests"
+									],
+									"query": [
+										{
+											"key": "page",
+											"value": "1"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "PageSize Without Page",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status test\", function () {\r",
+											"    pm.response.to.have.status(400);\r",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/trainingrequests?pageSize=20",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"trainingrequests"
+									],
+									"query": [
+										{
+											"key": "pageSize",
+											"value": "20"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Wrong Format",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status test\", function () {\r",
+											"    pm.response.to.have.status(400);\r",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/trainingrequests?format=txt",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"trainingrequests"
+									],
+									"query": [
+										{
+											"key": "format",
+											"value": "txt"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Nonexistent Training Request",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status test\", function () {\r",
+											"    pm.response.to.have.status(404);\r",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/trainingrequests/111111111111111111111111",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"trainingrequests",
+										"111111111111111111111111"
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Guild Options",
+			"item": [
+				{
+					"name": "Get",
+					"item": [
+						{
+							"name": "Get Guild Options",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/guildoptions",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"guildoptions"
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									"const schema = {",
+									"    \"type\": \"object\",",
+									"    \"required\": [\"raidUnregisterNotificationTime\", \"raidReminderNotificationTime\", \"trainingRequestAutoSyncInterval\", \"trainingRequestInactiveDaysBeforeDisable\", \"raidAutoBroadcastTime\", \"commanderRoles\", \"officerRoles\"],",
+									"    \"properties\": {",
+									"        \"raidUnregisterNotificationTime\": { \"type\": \"number\" },",
+									"        \"raidReminderNotificationTime\": { \"type\": \"number\" },",
+									"        \"trainingRequestAutoSyncInterval\": {  \"type\": \"number\" },",
+									"        \"trainingRequestInactiveDaysBeforeDisable\": { \"type\": \"number\" },",
+									"        \"raidAutoBroadcastTime\": { \"type\": \"number\" },",
+									"        \"commanderRoles\": { \"type\": \"array\", \"items\": { \"type\": \"string\" }},",
+									"        \"officerRoles\": { \"type\": \"array\", \"items\": { \"type\": \"string\" }},",
+									"        \"memberRoleId\": { \"type\": \"string\" },",
+									"        \"guildApplicationsChannelId\": { \"type\": \"string\" },",
+									"        \"raidCategoryId\": { \"type\": \"string\" },",
+									"        \"raidDraftCategoryId\": { \"type\": \"string\" }",
+									"    },",
+									"    \"additionalProperties\": false",
+									"}",
+									"",
+									"pm.test(\"Status test\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Content-Type is present\", function () {",
+									"    pm.response.to.have.header(\"Content-Type\");",
+									"});",
+									"",
+									"pm.test(\"Schema test\", function () {",
+									"    pm.response.to.have.jsonSchema(schema);",
+									"});"
+								]
+							}
+						}
+					]
+				},
+				{
+					"name": "Errors",
+					"item": [
+						{
+							"name": "Bad Authentication",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status test\", function () {\r",
+											"    pm.response.to.have.status(401);\r",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "noauth"
+								},
+								"method": "GET",
+								"header": [
+									{
+										"warning": "This is a duplicate header and will be overridden by the Authorization header generated by Postman.",
+										"key": "Authorization",
+										"value": "Bearer 123456789",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{baseUrl}}/guildoptions",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"guildoptions"
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Other",
+			"item": [
+				{
+					"name": "GET /status",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"const schema = {\r",
+									"    \"type\": \"object\",\r",
+									"    \"required\": [\"timestamp\", \"processInfo\", \"apiInfo\", \"systemInfo\"],\r",
+									"    \"items\": {\r",
+									"        \"type\": \"object\",\r",
+									"        \"properties\": {\r",
+									"            \"timestamp\": { \"type\": \"number\" },\r",
+									"            \"processInfo\": {\r",
+									"                \"type\": \"object\",\r",
+									"                \"required\": [\"uptime\", \"pid\", \"title\", \"environment\"],\r",
+									"                \"properties\": {\r",
+									"                    \"uptime\": { \"type\": \"string\" },\r",
+									"                    \"pid\": { \"type\": \"number\" },\r",
+									"                    \"title\": { \"type\": \"string\" },\r",
+									"                    \"environment\": { \"type\": \"string\", \"enum\": [\"Debug\", \"Release\"] }\r",
+									"                },\r",
+									"                \"additionalProperties\": false\r",
+									"            },\r",
+									"            \"apiInfo\": {\r",
+									"                \"type\": \"object\",\r",
+									"                \"required\": [\"apiName\", \"apiVersion\", \"guildId\", \"gitVersionInfo\"],\r",
+									"                \"properties\": {\r",
+									"                    \"apiName\": { \"type\": \"string\" },\r",
+									"                    \"apiVersion\": { \"type\": \"string\" },\r",
+									"                    \"guildId\": { \"type\": \"string\" },\r",
+									"                    \"gitVersionInfo\": {\r",
+									"                        \"type\": \"object\",\r",
+									"                        \"properties\": {\r",
+									"                            \"branch\": { \"type\": \"string\" },\r",
+									"                            \"commitId\": { \"type\": \"string\" }\r",
+									"                        }\r",
+									"                    }\r",
+									"                },\r",
+									"                \"additionalProperties\": false\r",
+									"            },\r",
+									"            \"systemInfo\": {\r",
+									"                \"type\": \"object\",\r",
+									"                \"required\": [\"platform\", \"type\", \"hostname\", \"release\", \"memory\", \"cores\"],\r",
+									"                \"properties\": {\r",
+									"                    \"platform\": { \"type\": \"string\" },\r",
+									"                    \"type\": { \"type\": \"string\" },\r",
+									"                    \"hostname\": { \"type\": \"string\" },\r",
+									"                    \"release\": { \"type\": \"string\" },\r",
+									"                    \"memory\": { \"type\": \"number\" },\r",
+									"                    \"cores\": { \"type\": \"number\" }\r",
+									"                },\r",
+									"                \"additionalProperties\": false\r",
+									"            },\r",
+									"        },\r",
+									"        \"additionalProperties\": false\r",
+									"    }\r",
+									"}\r",
+									"\r",
+									"pm.test(\"Status test\", function () {\r",
+									"    pm.response.to.have.status(200);\r",
+									"});\r",
+									"\r",
+									"pm.test(\"Content-Type is present\", function () {\r",
+									"    pm.response.to.have.header(\"Content-Type\");\r",
+									"});\r",
+									"\r",
+									"pm.test(\"Schema test\", function () {\r",
+									"    pm.response.to.have.jsonSchema(schema);\r",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "noauth"
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/status",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"status"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "GET /stats",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status test\", function () {\r",
+									"    pm.response.to.have.status(200);\r",
+									"});\r",
+									"\r",
+									"pm.test(\"Content-Type is present\", function () {\r",
+									"    pm.response.to.have.header(\"Content-Type\");\r",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "noauth"
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/stats",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"stats"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "Discord Auth",
+			"item": [
+				{
+					"name": "Post",
+					"item": [
+						{
+							"name": "Post Discord Auth",
+							"request": {
+								"auth": {
+									"type": "noauth"
+								},
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n    \"code\": \"DISCORD_OAUTH2_CODE\"\r\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseUrl}}/discordauth",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"discordauth"
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				}
+			]
+		}
+	],
+	"auth": {
+		"type": "bearer",
+		"bearer": [
+			{
+				"key": "token",
+				"value": "{{rtiApiToken}}",
+				"type": "string"
+			}
+		]
+	},
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		}
+	]
 }

--- a/spec/examples/snippets/participants-list.json
+++ b/spec/examples/snippets/participants-list.json
@@ -1,0 +1,10 @@
+[
+  "Mark#1561",
+  "Tom#6520",
+  "Sarah#5692",
+  "Johnny T#2048",
+  "Jane#7732",
+  "Mervin#2206",
+  "Florence#2415",
+  "Steven#9518"
+]

--- a/spec/rti-api.raml
+++ b/spec/rti-api.raml
@@ -37,7 +37,7 @@ traits:
       leader:
         type: string
         description: A case-insensitive string with all numbers and dots and hashtags removed to filter the raids by leader name.
-        example: Step
+        example: "Step"
       published:
         type: boolean
         description: A boolean indicating whether or not to only output published raids.
@@ -50,6 +50,31 @@ traits:
         type: string
         description: A comma-separated, case-sensitive string to filter the raids by reserves' Discord names. All reserves in this query list have to be present as reserves in the raid.
         example: "step%230,akronox%230"
+      format:
+        type: string
+        description: A case-insensitive string specifying what format to return.
+        enum: ["json", "csv"]
+      page:
+        type: number
+        description: The page to return. If this query parameter is specified, then pageSize must also be specified.
+        example: 1
+      pageSize:
+        type: number
+        description: The number of elements in each page in the response. If this query parameter is specified, then page must also be specified.
+        example: 20
+      dateFrom:
+        type: string
+        description: The timestamp to filter for raids scheduled after this date and time. In the format yyyy-MM-ddTHH:mm:ss. dateFrom must be before dateTo.
+        example: "2021-10-06T00:00:00"
+      dateTo:
+        type: string
+        description: The timestamp to filter for raids scheduled before this date and time. In the format yyyy-MM-ddTHH:mm:ss. dateTo must be after dateFrom.
+        example: "2022-10-06T00:00:00"
+      showParticipants:
+        type: boolean
+        description: Whether to output the list of participants under each raid or not.
+        example: true
+        default: false
     responses:
       200:
         body:

--- a/spec/types/RaidSummary.raml
+++ b/spec/types/RaidSummary.raml
@@ -30,6 +30,15 @@ properties:
     type: datetime-only
     description: The date and time that the raid is scheduled to start. In the format yyyy-MM-ddTHH:mm:ss.
     example: "2021-01-31T14:37:21"
+  participants:
+    type: array
+    description: A list of participants outputted as Discord names.
+    required: false
+    example: [
+      "John#1562",
+      "Bob Brown#6293",
+      "Step#1937"
+    ]
   id:
     type: string
     description: The internal ID of the raid as a 12-byte hexadecimal string.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,10 +5,10 @@
     "outDir": "dist",
     "sourceMap": true,
     "strictNullChecks": true,
-    "noUnusedLocals": true,
+    "noUnusedLocals": false,
     "baseUrl": ".",
     "moduleResolution": "node",
-    "typeRoots": ["node_modules/@types"],
+    "typeRoots": ["node_modules/"],
     "paths": {
       "@RTIBot-DB/*": ["RTIBot-DB/*"]
     },


### PR DESCRIPTION
This PR implements a date filter and `showParticipants` feature.

- There are two new query parameters for the date filter: `dateFrom` and `dateTo`. These both expect timestamps in the format `yyyy-MM-ddTHH:mm:ss` and `dateFrom` cannot be greater than `dateTo`. These are also both optional.
- There is a new `showParticipants` query parameter which lists all participants for each raid in the `GET /raids` endpoint if set to `true`. By default, this is set to `false`.
- README was updated since `localhost` isn't supported anymore: use `0.0.0.0` instead.
- Relevant Postman, unit tests, and RAML updated.